### PR TITLE
Update macOS requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and a [growing list of clients][mcp-clients] that support the
 ### Download and open the app
 
 First, [download the iMCP app](https://iMCP.app/download)
-(requires macOS 15 or later).
+(requires macOS 15.3 or later).
 
 <img align="right" width="344" src="/Assets/imcp-screenshot-first-launch.png" alt="Screenshot of iMCP on first launch" />
 


### PR DESCRIPTION
Some users are reporting that the app isn't working for them, and we suspect it has to do with running a slightly older release of macOS (even though the app configures its minimum target to macOS 15.1).

While we figure out the underlying cause, this PR updates the README to make the 15.3 requirement explicit.