### PR TITLE
Configure JSON encoding format options for tool output

### DIFF
--- a/App/Models/Tool.swift
+++ b/App/Models/Tool.swift
@@ -17,7 +17,12 @@ public struct Tool: Sendable {
         self.inputSchema = inputSchema
         self.implementation = { input in
             let result = try await implementation(input)
-            let data = try JSONEncoder().encode(result)
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+            let data = try encoder.encode(result)
+
             let decoder = JSONDecoder()
             return try decoder.decode(Value.self, from: data)
         }


### PR DESCRIPTION
Sort keys and don't escape slashes.