### PR TITLE
Support the `env` field for entries in the Claude Desktop config

### DIFF
--- a/App/Integrations/ClaudeDesktop.swift
+++ b/App/Integrations/ClaudeDesktop.swift
@@ -20,6 +20,7 @@ enum ClaudeDesktop {
         struct MCPServer: Codable {
             var command: String
             var args: [String]?
+            var env: [String: String]?
         }
 
         var mcpServers: [String: MCPServer]


### PR DESCRIPTION
The model for the Claude Desktop config was not considering that some configs use an `env` key for storing a `[String: String]` dictionary of environment variables, which is often used for access tokens, API keys and similar. This would cause these `env` keys to be wiped when the iMCP config was added.

This PR adds support for the `env` key.

Closes: #47 