### PR TITLE
Restrict Bonjour discovery to only local machine

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -2,8 +2,8 @@ import AppKit
 import Logging
 import MCP
 import Network
-import Ontology
 import OSLog
+import Ontology
 import SwiftUI
 import SystemPackage
 
@@ -256,8 +256,7 @@ actor ServerNetworkManager {
         // Set up Bonjour service
         let parameters = NWParameters.tcp
         parameters.acceptLocalOnly = true
-        parameters.attribution = .user
-        parameters.includePeerToPeer = true
+        parameters.includePeerToPeer = false
 
         if let tcpOptions = parameters.defaultProtocolStack.internetProtocol
             as? NWProtocolIP.Options

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -18,7 +18,8 @@ log.logLevel = .debug
 // Network setup
 let serviceType = "_mcp._tcp"
 let parameters = NWParameters.tcp
-parameters.includePeerToPeer = true
+parameters.acceptLocalOnly = true
+parameters.includePeerToPeer = false
 
 if let tcpOptions = parameters.defaultProtocolStack.internetProtocol as? NWProtocolIP.Options {
     tcpOptions.version = .v4


### PR DESCRIPTION
The current configuration for `NWParameters` objects in the client and server allows for connection with other local devices, which was not intended. The CLI tool is designed to work with a locally running iMCP app instance, so there's no need for network-wide or peer-to-peer discovery.

This PR makes the following changes:

- Set `acceptLocalOnly = true` to restrict network connections to localhost
- Set `includePeerToPeer = false` to disable WiFi Direct/Bluetooth discovery
- Set `attribution = .developer` (by omitting, since it's default) as service discovery is app-configured
