### PR TITLE
Preserve Claude Desktop configuration values when adding iMCP

### DIFF
--- a/App/Integrations/ClaudeDesktop.swift
+++ b/App/Integrations/ClaudeDesktop.swift
@@ -94,8 +94,8 @@ private func getSecurityScopedConfigURL() throws -> URL? {
         bookmarkDataIsStale: &isStale)
 
     if isStale {
-        log.debug("Bookmark data is stale")
-        return nil
+        log.debug("Bookmark data is stale but URL was resolved: \(url.path). Attempting to use it.")
+        // We will still return the URL and let the caller try to use it and refresh the bookmark.
     }
 
     log.debug("Successfully retrieved security-scoped URL: \(url.path)")
@@ -120,23 +120,72 @@ private func loadConfig() throws -> ([String: Value], ClaudeDesktop.Config.MCPSe
             .appendingPathComponent("Contents/MacOS/imcp-server")
             .path)
 
-    var config: [String: Value] = ["mcpServers": .object([:])]
+    var loadedConfiguration: [String: Value]?
 
-    // Try to load existing config if it exists
-    if let secureURL = try? getSecurityScopedConfigURL(),
-        secureURL.startAccessingSecurityScopedResource(),
-        FileManager.default.fileExists(atPath: secureURL.path)
-    {
-        defer { secureURL.stopAccessingSecurityScopedResource() }
-
-        log.debug("Loading existing configuration from: \(secureURL.path)")
-        let data = try Data(contentsOf: secureURL)
-        config = try jsonDecoder.decode([String: Value].self, from: data)
+    // 1. Try to load using security-scoped URL
+    if let secureURL = try? getSecurityScopedConfigURL() {
+        log.debug("Attempting to load from security-scoped URL: \(secureURL.path)")
+        if secureURL.startAccessingSecurityScopedResource() {
+            defer { secureURL.stopAccessingSecurityScopedResource() }
+            if FileManager.default.fileExists(atPath: secureURL.path) {
+                do {
+                    log.debug("Loading existing configuration from: \(secureURL.path)")
+                    let data = try Data(contentsOf: secureURL)
+                    loadedConfiguration = try jsonDecoder.decode([String: Value].self, from: data)
+                    log.debug(
+                        "Successfully loaded from security-scoped URL. Attempting to refresh bookmark."
+                    )
+                    try saveSecurityScopedAccess(for: secureURL)  // Refresh bookmark
+                } catch {
+                    log.error(
+                        "Failed to load or decode from security-scoped URL \(secureURL.path): \(error.localizedDescription)"
+                    )
+                }
+            } else {
+                log.debug(
+                    "Security-scoped URL \(secureURL.path) does not point to an existing file.")
+            }
+        } else {
+            log.debug(
+                "Failed to start accessing security-scoped resource for URL: \(secureURL.path)")
+        }
     } else {
-        log.debug("No existing config found or accessible, will create a new one")
+        log.debug("No security-scoped URL obtained or an error occurred retrieving it.")
     }
 
-    return (config, imcpServer)
+    // 2. If config is still nil (not loaded via security scope), try to load from default direct path
+    if loadedConfiguration == nil {
+        let defaultURL = URL(fileURLWithPath: configPath)
+        log.debug("Attempting to load from default direct path: \(defaultURL.path)")
+        if FileManager.default.fileExists(atPath: defaultURL.path) {
+            do {
+                let data = try Data(contentsOf: defaultURL)
+                loadedConfiguration = try jsonDecoder.decode([String: Value].self, from: data)
+                log.debug(
+                    "Successfully loaded from default path. Attempting to save security bookmark for it."
+                )
+                try saveSecurityScopedAccess(for: defaultURL)  // Establish bookmark if loaded directly
+            } catch {
+                log.error(
+                    "Failed to load or decode from default path \(defaultURL.path): \(error.localizedDescription)"
+                )
+            }
+        } else {
+            log.debug("Default config file \(defaultURL.path) does not exist.")
+        }
+    }
+
+    // 3. Use loaded configuration or fall back to default if still nil
+    let finalConfig =
+        loadedConfiguration
+        ?? {
+            log.notice(
+                "No existing config found or accessible after all attempts. Creating a new default configuration."
+            )
+            return ["mcpServers": .object([:])]
+        }()
+
+    return (finalConfig, imcpServer)
 }
 
 private func updateConfig(
@@ -156,16 +205,41 @@ private func updateConfig(
         updatedConfig["mcpServers"] = .object(["iMCP": imcpServerValue])
     }
 
-    // If we have an existing security-scoped URL, try to use it
+    // First try with the security-scoped URL if available
     if let secureURL = try? getSecurityScopedConfigURL() {
         if secureURL.startAccessingSecurityScopedResource() {
             defer { secureURL.stopAccessingSecurityScopedResource() }
-            try writeConfig(updatedConfig, to: secureURL)
-            return
+            do {
+                try writeConfig(updatedConfig, to: secureURL)
+                return
+            } catch {
+                log.error("Failed to write to security-scoped URL: \(error.localizedDescription)")
+                // Continue to fallback options
+            }
+        } else {
+            log.error("Failed to access security-scoped resource")
         }
     }
 
-    // Show save panel for new location
+    // Then try to use the default path directly if it exists and is writable
+    let defaultURL = URL(fileURLWithPath: configPath)
+    if FileManager.default.fileExists(atPath: configPath) {
+        do {
+            // Test if we can write to this file
+            if FileManager.default.isWritableFile(atPath: configPath) {
+                try writeConfig(updatedConfig, to: defaultURL)
+
+                // Since we succeeded with direct path, create a bookmark for future use
+                try? saveSecurityScopedAccess(for: defaultURL)
+                return
+            }
+        } catch {
+            log.error("Failed to write to default config path: \(error.localizedDescription)")
+            // Continue to show save panel
+        }
+    }
+
+    // Finally, show save panel as a last resort
     log.debug("Showing save panel for new configuration location")
     let savePanel = NSSavePanel()
     savePanel.message = "Choose where to save the iMCP server settings."
@@ -183,11 +257,16 @@ private func updateConfig(
 
     // Create the file first
     log.debug("Creating configuration at selected URL: \(selectedURL.path)")
-    try writeConfig(updatedConfig, to: selectedURL)
+    do {
+        try writeConfig(updatedConfig, to: selectedURL)
 
-    // Then create the security-scoped bookmark
-    log.debug("Creating security-scoped access for selected URL")
-    try saveSecurityScopedAccess(for: selectedURL)
+        // Then create the security-scoped bookmark
+        log.debug("Creating security-scoped access for selected URL")
+        try saveSecurityScopedAccess(for: selectedURL)
+    } catch {
+        log.error("Failed to write config to selected URL: \(error)")
+        throw error
+    }
 }
 
 private func writeConfig(_ config: [String: Value], to url: URL) throws {


### PR DESCRIPTION
Resolves #47 

This PR takes another pass at how we load and write Claude Desktop configuration. Instead of encoding and decoding through a distinct `Codable` value, we now use a generic dictionary, which preserves the original JSON object values.