### PR TITLE
Define tool schemas using `JSONSchema` package

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -771,7 +771,7 @@ actor ServerNetworkManager {
                                 .init(
                                     name: tool.name,
                                     description: tool.description,
-                                    inputSchema: tool.inputSchema
+                                    inputSchema: try Value(tool.inputSchema)
                                 )
                             )
                         }

--- a/App/Extensions/EventKit+Extensions.swift
+++ b/App/Extensions/EventKit+Extensions.swift
@@ -1,0 +1,76 @@
+import EventKit
+
+extension EKEventAvailability {
+    init(_ string: String) {
+        switch string.lowercased() {
+        case "busy": self = .busy
+        case "free": self = .free
+        case "tentative": self = .tentative
+        case "unavailable": self = .unavailable
+        default: self = .busy
+        }
+    }
+
+    static var allCases: [EKEventAvailability] {
+        return [.busy, .free, .tentative, .unavailable]
+    }
+
+    var stringValue: String {
+        switch self {
+        case .busy: return "busy"
+        case .free: return "free"
+        case .tentative: return "tentative"
+        case .unavailable: return "unavailable"
+        default: return "unknown"
+        }
+    }
+}
+
+extension EKEventStatus {
+    init(_ string: String) {
+        switch string.lowercased() {
+        case "none": self = .none
+        case "tentative": self = .tentative
+        case "confirmed": self = .confirmed
+        case "canceled": self = .canceled
+        default: self = .none
+        }
+    }
+}
+
+extension EKRecurrenceFrequency {
+    init(_ string: String) {
+        switch string.lowercased() {
+        case "daily": self = .daily
+        case "weekly": self = .weekly
+        case "monthly": self = .monthly
+        case "yearly": self = .yearly
+        default: self = .daily
+        }
+    }
+}
+
+extension EKReminderPriority {
+    static func from(string: String) -> EKReminderPriority {
+        switch string.lowercased() {
+        case "high": return .high
+        case "medium": return .medium
+        case "low": return .low
+        default: return .none
+        }
+    }
+
+    static var allCases: [EKReminderPriority] {
+        return [.none, .low, .medium, .high]
+    }
+
+    var stringValue: String {
+        switch self {
+        case .high: return "high"
+        case .medium: return "medium"
+        case .low: return "low"
+        case .none: return "none"
+        @unknown default: return "unknown"
+        }
+    }
+}

--- a/App/Models/Tool.swift
+++ b/App/Models/Tool.swift
@@ -1,17 +1,18 @@
 import Foundation
 import MCP
 import Ontology
+import JSONSchema
 
 public struct Tool: Sendable {
     let name: String
     let description: String
-    let inputSchema: Value
+    let inputSchema: JSONSchema
     private let implementation: @Sendable ([String: Value]) async throws -> Value
 
     public init<T: Encodable>(
         name: String,
         description: String,
-        inputSchema: Value,
+        inputSchema: JSONSchema,
         implementation: @Sendable @escaping ([String: Value]) async throws -> T
     ) {
         self.name = name

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -24,54 +24,47 @@ final class CalendarService: Service {
         Tool(
             name: "fetchEvents",
             description: "Get events from the calendar with flexible filtering options",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "startDate": [
-                        "type": "string",
-                        "description":
-                            "ISO date string for the start of the date range (defaults to now if not specified)",
-                    ],
-                    "endDate": [
-                        "type": "string",
-                        "description":
-                            "ISO date string for the end of the date range (defaults to one week from start if not specified)",
-                    ],
-                    "calendarNames": [
-                        "type": "array",
-                        "items": ["type": "string"],
-                        "description":
+            inputSchema: .object(
+                properties: [
+                    "startDate": .string(
+                        description:
+                            "The start of the date range (defaults to now if not specified)",
+                        format: .dateTime
+                    ),
+                    "endDate": .string(
+                        description:
+                            "The end of the date range (defaults to one week from start if not specified)",
+                        format: .dateTime
+                    ),
+                    "calendarNames": .array(
+                        description:
                             "Names of calendars to fetch from. If empty or not specified, fetches from all calendars.",
-                    ],
-                    "searchText": [
-                        "type": "string",
-                        "description": "Text to search for in event titles and locations",
-                    ],
-                    "includeAllDay": [
-                        "type": "boolean",
-                        "description": "Whether to include all-day events",
-                        "default": true,
-                    ],
-                    "status": [
-                        "type": "string",
-                        "enum": ["none", "tentative", "confirmed", "canceled"],
-                        "description": "Filter by event status",
-                    ],
-                    "availability": [
-                        "type": "string",
-                        "enum": ["busy", "free", "tentative", "unavailable"],
-                        "description": "Filter by availability status",
-                    ],
-                    "hasAlarms": [
-                        "type": "boolean",
-                        "description": "Filter for events that have alarms/reminders set",
-                    ],
-                    "isRecurring": [
-                        "type": "boolean",
-                        "description": "Filter for recurring/non-recurring events",
-                    ],
+                        items: .string(),
+                    ),
+                    "searchText": .string(
+                        description: "Text to search for in event titles and locations"
+                    ),
+                    "includeAllDay": .boolean(
+                        description: "Whether to include all-day events",
+                        default: true
+                    ),
+                    "status": .string(
+                        description: "Filter by event status",
+                        enum: ["none", "tentative", "confirmed", "canceled"]
+                    ),
+                    "availability": .string(
+                        description: "Filter by availability status",
+                        enum: EKEventAvailability.allCases.map { .string($0.stringValue) }
+                    ),
+                    "hasAlarms": .boolean(
+                        description: "Filter for events that have alarms/reminders set"
+                    ),
+                    "isRecurring": .boolean(
+                        description: "Filter for recurring/non-recurring events"
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             guard EKEventStore.authorizationStatus(for: .event) == .fullAccess else {
                 log.error("Calendar access not authorized")
@@ -159,87 +152,50 @@ final class CalendarService: Service {
         Tool(
             name: "createEvent",
             description: "Create a new calendar event with specified properties",
-            inputSchema: [
-                "type": "object",
-                "required": ["title", "startDate", "endDate"],
-                "properties": [
-                    "title": [
-                        "type": "string",
-                        "description": "The title of the event",
-                    ],
-                    "startDate": [
-                        "type": "string",
-                        "description": "ISO date string for the event start time",
-                    ],
-                    "endDate": [
-                        "type": "string",
-                        "description": "ISO date string for the event end time",
-                    ],
-                    "calendarName": [
-                        "type": "string",
-                        "description":
-                            "Name of the calendar to create the event in (uses default calendar if not specified)",
-                    ],
-                    "location": [
-                        "type": "string",
-                        "description": "Location of the event",
-                    ],
-                    "notes": [
-                        "type": "string",
-                        "description": "Notes or description for the event",
-                    ],
-                    "url": [
-                        "type": "string",
-                        "description": "URL associated with the event (e.g., meeting link)",
-                    ],
-                    "isAllDay": [
-                        "type": "boolean",
-                        "description": "Whether this is an all-day event",
-                        "default": false,
-                    ],
-                    "availability": [
-                        "type": "string",
-                        "enum": ["busy", "free", "tentative", "unavailable"],
-                        "description": "Availability status for the event",
-                        "default": "busy",
-                    ],
-                    "alarms": [
-                        "type": "array",
-                        "items": [
-                            "type": "integer"
-                        ],
-                        "description":
-                            "Array of minutes before the event to set alarms (e.g., [0, 15, 60] for notifications at event time, 15 mins before, and 1 hour before)",
-                    ],
-                    "recurrence": [
-                        "type": "object",
-                        "description": "Recurrence rules for the event",
-                        "properties": [
-                            "frequency": [
-                                "type": "string",
-                                "enum": ["daily", "weekly", "monthly", "yearly"],
-                                "description": "How often the event repeats",
-                            ],
-                            "interval": [
-                                "type": "integer",
-                                "description":
-                                    "Interval of the frequency (e.g., 2 for every 2 weeks)",
-                                "default": 1,
-                            ],
-                            "endDate": [
-                                "type": "string",
-                                "description":
-                                    "ISO date string for when the recurrence ends (optional)",
-                            ],
-                            "occurrences": [
-                                "type": "integer",
-                                "description":
-                                    "Number of occurrences (optional, alternative to endDate)",
-                            ],
-                        ],
-                    ],
+            inputSchema: .object(
+                properties: [
+                    "title": .string(
+                        description: "The title of the event"
+                    ),
+                    "startDate": .string(
+                        description: "The start of the event",
+                        format: .dateTime
+                    ),
+                    "endDate": .string(
+                        description: "The end of the event",
+                        format: .dateTime
+                    ),
+                    "calendarName": .string(
+                        description:
+                            "Name of the calendar to create the event in (uses default calendar if not specified)"
+                    ),
+                    "location": .string(
+                        description: "Location of the event"
+                    ),
+                    "notes": .string(
+                        description: "Notes or description for the event"
+                    ),
+                    "url": .string(
+                        description: "URL associated with the event (e.g., meeting link)",
+                        format: .uri
+                    ),
+                    "isAllDay": .boolean(
+                        description: "Whether this is an all-day event",
+                        default: false
+                    ),
+                    "availability": .string(
+                        description: "Event availability status",
+                        default: .string(EKEventAvailability.busy.stringValue),
+                        enum: EKEventAvailability.allCases.map { .string($0.stringValue) }
+                    ),
+                    "alarms": .array(
+                        description: "Array of minutes before the event to set alarms",
+                        items: .integer()
+                    ),
                 ],
-            ]
+                required: ["title", "startDate", "endDate"],
+                additionalProperties: false
+            )
         ) { arguments in
             try await self.activate()
 
@@ -338,75 +294,10 @@ final class CalendarService: Service {
                 }
             }
 
-            // Set recurrence rules
-            if case let .object(recurrence) = arguments["recurrence"],
-                case let .string(frequencyStr) = recurrence["frequency"]
-            {
-                let recurrenceRule = EKRecurrenceRule(
-                    recurrenceWith: EKRecurrenceFrequency(frequencyStr),
-                    interval: {
-                        if case let .int(interval) = recurrence["interval"] {
-                            return interval
-                        }
-                        return 1
-                    }(),
-                    end: {
-                        if case let .string(endDateStr) = recurrence["endDate"],
-                            let endDate = dateFormatter.date(from: endDateStr)
-                        {
-                            return EKRecurrenceEnd(end: endDate)
-                        }
-                        if case let .int(occurrences) = recurrence["occurrences"] {
-                            return EKRecurrenceEnd(occurrenceCount: occurrences)
-                        }
-                        return nil
-                    }()
-                )
-                event.recurrenceRules = [recurrenceRule]
-            }
-
             // Save the event
             try self.eventStore.save(event, span: .thisEvent)
 
             return Event(event)
-        }
-    }
-}
-
-// MARK: -
-
-extension EKEventAvailability {
-    fileprivate init(_ string: String) {
-        switch string.lowercased() {
-        case "busy": self = .busy
-        case "free": self = .free
-        case "tentative": self = .tentative
-        case "unavailable": self = .unavailable
-        default: self = .busy
-        }
-    }
-}
-
-extension EKEventStatus {
-    fileprivate init(_ string: String) {
-        switch string.lowercased() {
-        case "none": self = .none
-        case "tentative": self = .tentative
-        case "confirmed": self = .confirmed
-        case "canceled": self = .canceled
-        default: self = .none
-        }
-    }
-}
-
-extension EKRecurrenceFrequency {
-    fileprivate init(_ string: String) {
-        switch string.lowercased() {
-        case "daily": self = .daily
-        case "weekly": self = .weekly
-        case "monthly": self = .monthly
-        case "yearly": self = .yearly
-        default: self = .daily
         }
     }
 }

--- a/App/Services/Contacts.swift
+++ b/App/Services/Contacts.swift
@@ -68,11 +68,12 @@ final class ContactsService: Service {
     var tools: [Tool] {
         Tool(
             name: "whoami",
-            description: "Get contact information about the user, including name, phone number, email, birthday, relations, address, online presence, and occupation. Always run this tool when the user asks a question that requires personal information about themselves.",
-            inputSchema: [
-                "type": "object",
-                "properties": [:],
-            ]
+            description:
+                "Get contact information about the user, including name, phone number, email, birthday, relations, address, online presence, and occupation. Always run this tool when the user asks a question that requires personal information about themselves.",
+            inputSchema: .object(
+                properties: [:],
+                additionalProperties: false
+            )
         ) { _ in
             let contact = try self.contactStore.unifiedMeContactWithKeys(toFetch: contactKeys)
             return Person(contact)
@@ -82,23 +83,20 @@ final class ContactsService: Service {
             name: "searchContacts",
             description:
                 "Search contacts by name, phone number, and/or email. Provide only the parameters you want to search by. Provide at least one parameter.",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "name": [
-                        "type": "string",
-                        "description": "Name to search for (will match given name or family name)",
-                    ],
-                    "phone": [
-                        "type": "string",
-                        "description": "Phone number to search for (any formatting accepted)",
-                    ],
-                    "email": [
-                        "type": "string",
-                        "description": "Email address to search for (case insensitive)",
-                    ],
+            inputSchema: .object(
+                properties: [
+                    "name": .string(
+                        description: "Name to search for (will match given name or family name)"
+                    ),
+                    "phone": .string(
+                        description: "Phone number to search for (any formatting accepted)"
+                    ),
+                    "email": .string(
+                        description: "Email address to search for (case insensitive)"
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             var predicates: [NSPredicate] = []
 
@@ -118,7 +116,8 @@ final class ContactsService: Service {
                 // Normalize email to lowercase
                 let normalizedEmail = email.trimmingCharacters(in: .whitespaces).lowercased()
                 if !normalizedEmail.isEmpty {
-                    predicates.append(CNContact.predicateForContacts(matchingEmailAddress: normalizedEmail))
+                    predicates.append(
+                        CNContact.predicateForContacts(matchingEmailAddress: normalizedEmail))
                 }
             }
 

--- a/App/Services/Location.swift
+++ b/App/Services/Location.swift
@@ -90,10 +90,10 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
         Tool(
             name: "getCurrentLocation",
             description: "Get the user's current location",
-            inputSchema: [
-                "type": "object",
-                "properties": [:],
-            ]
+            inputSchema: .object(
+                properties: [:],
+                additionalProperties: false
+            )
         ) { _ in
             return try await withCheckedThrowingContinuation {
                 (continuation: CheckedContinuation<GeoCoordinates, Error>) in
@@ -168,16 +168,15 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
         Tool(
             name: "geocodeAddress",
             description: "Convert an address to geographic coordinates",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "address": [
-                        "type": "string",
-                        "description": "The address to geocode",
-                    ]
+            inputSchema: .object(
+                properties: [
+                    "address": .string(
+                        description: "The address to geocode"
+                    )
                 ],
-                "required": ["address"],
-            ]
+                required: ["address"],
+                additionalProperties: false
+            )
         ) { arguments in
             guard let address = arguments["address"]?.stringValue else {
                 throw NSError(
@@ -259,14 +258,13 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
         Tool(
             name: "reverseGeocode",
             description: "Convert geographic coordinates to an address",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "latitude": ["type": "number"],
-                    "longitude": ["type": "number"],
+            inputSchema: .object(
+                properties: [
+                    "latitude": .number(),
+                    "longitude": .number(),
                 ],
-                "required": ["latitude", "longitude"],
-            ]
+                required: ["latitude", "longitude"]
+            )
         ) { arguments in
             guard let latitude = arguments["latitude"]?.doubleValue,
                 let longitude = arguments["longitude"]?.doubleValue

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -52,38 +52,33 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
         Tool(
             name: "fetchMessages",
             description: "Fetch messages from the Messages app",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "participants": [
-                        "type": "array",
-                        "items": ["type": "string"],
-                        "description":
+            inputSchema: .object(
+                properties: [
+                    "participants": .array(
+                        description:
                             "A list of participant handles. May be a phone number or email address. Phone numbers should be in E.164 format (leading + and country code, no spaces or punctuation).",
-                    ],
-                    "startDate": [
-                        "type": "string",
-                        "format": "date-time",
-                        "description":
+                        items: .string()
+                    ),
+                    "startDate": .string(
+                        description:
                             "ISO 8601 formatted date-time string for the start of the date range (inclusive)",
-                    ],
-                    "endDate": [
-                        "type": "string",
-                        "format": "date-time",
-                        "description":
+                        format: .dateTime
+                    ),
+                    "endDate": .string(
+                        description:
                             "ISO 8601 formatted date-time string for the end of the date range (exclusive)",
-                    ],
-                    "searchTerm": [
-                        "type": "string",
-                        "description": "Search term to filter messages by",
-                    ],
-                    "limit": [
-                        "type": "integer",
-                        "description": "Maximum number of messages to return",
-                        "default": .int(defaultLimit),
-                    ],
+                        format: .dateTime
+                    ),
+                    "searchTerm": .string(
+                        description: "Search term to filter messages by"
+                    ),
+                    "limit": .integer(
+                        description: "Maximum number of messages to return",
+                        default: .int(defaultLimit)
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             log.debug("Starting message fetch with arguments: \(arguments)")
             try await self.activate()

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -24,36 +24,33 @@ final class RemindersService: Service {
         Tool(
             name: "fetchReminders",
             description: "Get reminders from the reminders app with flexible filtering options",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "completed": [
-                        "type": "boolean",
-                        "description":
-                            "If true, fetch completed reminders. If false, fetch incomplete reminders. If not specified, fetch all reminders.",
-                    ],
-                    "startDate": [
-                        "type": "string",
-                        "description":
-                            "ISO date string for the start of the date range to fetch reminders from",
-                    ],
-                    "endDate": [
-                        "type": "string",
-                        "description":
-                            "ISO date string for the end of the date range to fetch reminders from",
-                    ],
-                    "listNames": [
-                        "type": "array",
-                        "items": ["type": "string"],
-                        "description":
+            inputSchema: .object(
+                properties: [
+                    "completed": .boolean(
+                        description:
+                            "If true, fetch completed reminders. If false, fetch incomplete reminders. If not specified, fetch all reminders."
+                    ),
+                    "startDate": .string(
+                        description:
+                            "The start of the date range to fetch reminders from",
+                        format: .dateTime
+                    ),
+                    "endDate": .string(
+                        description:
+                            "The end of the date range to fetch reminders from",
+                        format: .dateTime
+                    ),
+                    "listNames": .array(
+                        description:
                             "Names of reminder lists to fetch from. If empty or not specified, fetches from all lists.",
-                    ],
-                    "searchText": [
-                        "type": "string",
-                        "description": "Text to search for in reminder titles",
-                    ],
+                        items: .string()
+                    ),
+                    "searchText": .string(
+                        description: "Text to search for in reminder titles"
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             try await self.activate()
 
@@ -135,39 +132,35 @@ final class RemindersService: Service {
         Tool(
             name: "createReminder",
             description: "Create a new reminder with specified properties",
-            inputSchema: [
-                "type": "object",
-                "required": ["title"],
-                "properties": [
-                    "title": [
-                        "type": "string",
-                        "description": "The title of the reminder",
-                    ],
-                    "dueDate": [
-                        "type": "string",
-                        "description": "ISO date string for when the reminder is due",
-                    ],
-                    "listName": [
-                        "type": "string",
-                        "description":
-                            "Name of the reminder list to add the reminder to (uses default if not specified)",
-                    ],
-                    "notes": [
-                        "type": "string",
-                        "description": "Additional notes for the reminder",
-                    ],
-                    "priority": [
-                        "type": "integer",
-                        "description": "Priority level (0 = none, 1 = low, 5 = medium, 9 = high)",
-                        "default": 0,
-                    ],
-                    "alarms": [
-                        "type": "array",
-                        "items": ["type": "integer"],
-                        "description": "Array of minutes before the due date to set alarms",
-                    ],
+            inputSchema: .object(
+                properties: [
+                    "title": .string(
+                        description: "The title of the reminder"
+                    ),
+                    "dueDate": .string(
+                        description: "The due date of the reminder",
+                        format: .dateTime
+                    ),
+                    "listName": .string(
+                        description:
+                            "Name of the reminder list to add the reminder to (uses default if not specified)"
+                    ),
+                    "notes": .string(
+                        description: "Additional notes for the reminder"
+                    ),
+                    "priority": .string(
+                        description: "The priority of the reminder",
+                        default: .string(EKReminderPriority.none.stringValue),
+                        enum: EKReminderPriority.allCases.map { .string($0.stringValue) }
+                    ),
+                    "alarms": .array(
+                        description: "The minutes before the due date to set alarms",
+                        items: .integer()
+                    ),
                 ],
-            ]
+                required: ["title"],
+                additionalProperties: false
+            )
         ) { arguments in
             try await self.activate()
 
@@ -213,8 +206,8 @@ final class RemindersService: Service {
                 reminder.notes = notes
             }
 
-            if case let .int(priority) = arguments["priority"] {
-                reminder.priority = Int(priority)
+            if case let .string(priorityStr) = arguments["priority"] {
+                reminder.priority = Int(EKReminderPriority.from(string: priorityStr).rawValue)
             }
 
             // Set alarms

--- a/App/Services/Utilities.swift
+++ b/App/Services/Utilities.swift
@@ -1,5 +1,6 @@
 import AppKit
 import OSLog
+import JSONSchema
 
 private let log = Logger.service("utilities")
 
@@ -29,17 +30,15 @@ final class UtilitiesService: Service {
         Tool(
             name: "playSystemSound",
             description: "Play a system sound. Only call if the user explicitly asks for it.",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "sound": [
-                        "type": "string",
-                        "default": .string(Sound.default.rawValue),
-                        "enum": .array(Sound.allCases.map { .string($0.rawValue) }),
-                    ]
+            inputSchema: .object(
+                properties: [
+                    "sound": .string(
+                        default: .string(Sound.default.rawValue),
+                        enum: Sound.allCases.map { .string($0.rawValue) })
                 ],
-                "required": ["sound"],
-            ]
+                required: ["sound"],
+                additionalProperties: false
+            )
         ) { input in
             let rawValue = input["sound"]?.stringValue ?? Sound.default.rawValue
             guard let sound = Sound(rawValue: rawValue),

--- a/App/Services/Weather.swift
+++ b/App/Services/Weather.swift
@@ -16,19 +16,17 @@ final class WeatherService: Service {
             name: "getCurrentWeatherForLocation",
             description:
                 "Get current weather for a location, including temperature, conditions, humidity, and wind speed",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "latitude": [
-                        "type": "number",
-                        "description": "The latitude of the location",
-                    ],
-                    "longitude": [
-                        "type": "number",
-                        "description": "The longitude of the location",
-                    ],
+            inputSchema: .object(
+                properties: [
+                    "latitude": .number(
+                        description: "The latitude of the location"
+                    ),
+                    "longitude": .number(
+                        description: "The longitude of the location"
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             guard case let .double(latitude) = arguments["latitude"],
                 case let .double(longitude) = arguments["longitude"]
@@ -50,26 +48,23 @@ final class WeatherService: Service {
         Tool(
             name: "getHourlyForecastForLocation",
             description: "Get hourly weather forecast for a location",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "latitude": [
-                        "type": "number",
-                        "description": "The latitude of the location",
-                    ],
-                    "longitude": [
-                        "type": "number",
-                        "description": "The longitude of the location",
-                    ],
-                    "hours": [
-                        "type": "integer",
-                        "description": "Number of hours to forecast",
-                        "default": 24,
-                        "minimum": 1,
-                        "maximum": 240,
-                    ],
+            inputSchema: .object(
+                properties: [
+                    "latitude": .number(
+                        description: "The latitude of the location"
+                    ),
+                    "longitude": .number(
+                        description: "The longitude of the location"
+                    ),
+                    "hours": .integer(
+                        description: "Number of hours to forecast",
+                        default: 24,
+                        minimum: 1,
+                        maximum: 240
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             guard case let .double(latitude) = arguments["latitude"],
                 case let .double(longitude) = arguments["longitude"]
@@ -101,26 +96,23 @@ final class WeatherService: Service {
         Tool(
             name: "getDailyForecastForLocation",
             description: "Get daily weather forecast for a location",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "latitude": [
-                        "type": "number",
-                        "description": "The latitude of the location",
-                    ],
-                    "longitude": [
-                        "type": "number",
-                        "description": "The longitude of the location",
-                    ],
-                    "days": [
-                        "type": "integer",
-                        "description": "Number of days to forecast (default 7, max 10)",
-                        "default": 7,
-                        "minimum": 1,
-                        "maximum": 10,
-                    ],
+            inputSchema: .object(
+                properties: [
+                    "latitude": .number(
+                        description: "The latitude of the location"
+                    ),
+                    "longitude": .number(
+                        description: "The longitude of the location"
+                    ),
+                    "days": .integer(
+                        description: "Number of days to forecast (default 7, max 10)",
+                        default: 7,
+                        minimum: 1,
+                        maximum: 10
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             guard case let .double(latitude) = arguments["latitude"],
                 case let .double(longitude) = arguments["longitude"]
@@ -150,26 +142,23 @@ final class WeatherService: Service {
         Tool(
             name: "getMinuteByMinuteForecastForLocation",
             description: "Get minute-by-minute weather forecast for a location",
-            inputSchema: [
-                "type": "object",
-                "properties": [
-                    "latitude": [
-                        "type": "number",
-                        "description": "The latitude of the location",
-                    ],
-                    "longitude": [
-                        "type": "number",
-                        "description": "The longitude of the location",
-                    ],
-                    "minutes": [
-                        "type": "integer",
-                        "description": "Number of minutes to forecast (default 60)",
-                        "default": 60,
-                        "minimum": 1,
-                        "maximum": 120,
-                    ],
+            inputSchema: .object(
+                properties: [
+                    "latitude": .number(
+                        description: "The latitude of the location"
+                    ),
+                    "longitude": .number(
+                        description: "The longitude of the location"
+                    ),
+                    "minutes": .integer(
+                        description: "Number of minutes to forecast (default 60)",
+                        default: 60,
+                        minimum: 1,
+                        maximum: 120
+                    ),
                 ],
-            ]
+                additionalProperties: false
+            )
         ) { arguments in
             guard case let .double(latitude) = arguments["latitude"],
                 case let .double(longitude) = arguments["longitude"]

--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		F8CE997B2D591CF200C61CA2 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8CE997A2D591CF200C61CA2 /* MCP */; };
 		F8D7C3172DCBD30500A4775F /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8D7C3162DCBD30500A4775F /* MCP */; };
 		F8D7C31A2DCBD32100A4775F /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8D7C3192DCBD32100A4775F /* MCP */; };
+		F8D8C48E2DCE0E6800369E5C /* JSONSchema in Frameworks */ = {isa = PBXBuildFile; productRef = F8D8C48D2DCE0E6800369E5C /* JSONSchema */; };
 		F8F1D2F82D6F9E0C00F6323D /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8F44E9C2D5903F70075D79C /* MCP */; };
 		F8F1D33F2D6FA7EB00F6323D /* MacControlCenterUI in Frameworks */ = {isa = PBXBuildFile; productRef = F8F1D33E2D6FA7EB00F6323D /* MacControlCenterUI */; };
 /* End PBXBuildFile section */
@@ -89,6 +90,7 @@
 				F8F1D2F82D6F9E0C00F6323D /* MCP in Frameworks */,
 				F8D7C3172DCBD30500A4775F /* MCP in Frameworks */,
 				F80955702D7888920055B911 /* iMessage in Frameworks */,
+				F8D8C48E2DCE0E6800369E5C /* JSONSchema in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -153,6 +155,7 @@
 				F8A7DE3D2DCB76F700530587 /* MCP */,
 				F8D7C3162DCBD30500A4775F /* MCP */,
 				F8D7C3192DCBD32100A4775F /* MCP */,
+				F8D8C48D2DCE0E6800369E5C /* JSONSchema */,
 			);
 			productName = iMCP;
 			productReference = F8F44E6D2D59038D0075D79C /* iMCP.app */;
@@ -218,6 +221,7 @@
 				F809556C2D7888920055B911 /* XCRemoteSwiftPackageReference "madrid" */,
 				F825BDBD2D9AD00E0063ADD7 /* XCRemoteSwiftPackageReference "swift-service-lifecycle" */,
 				F8D7C3182DCBD32100A4775F /* XCRemoteSwiftPackageReference "swift-sdk" */,
+				F8D8C48C2DCE0E6800369E5C /* XCRemoteSwiftPackageReference "JSONSchema" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = F8F44E6E2D59038D0075D79C /* Products */;
@@ -572,6 +576,14 @@
 				kind = branch;
 			};
 		};
+		F8D8C48C2DCE0E6800369E5C /* XCRemoteSwiftPackageReference "JSONSchema" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/loopwork-ai/JSONSchema.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
+			};
+		};
 		F8F1D33D2D6FA7EB00F6323D /* XCRemoteSwiftPackageReference "MacControlCenterUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/orchetect/MacControlCenterUI";
@@ -629,6 +641,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8D7C3182DCBD32100A4775F /* XCRemoteSwiftPackageReference "swift-sdk" */;
 			productName = MCP;
+		};
+		F8D8C48D2DCE0E6800369E5C /* JSONSchema */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8D8C48C2DCE0E6800369E5C /* XCRemoteSwiftPackageReference "JSONSchema" */;
+			productName = JSONSchema;
 		};
 		F8F1D33E2D6FA7EB00F6323D /* MacControlCenterUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6929412a67fe9dc534eee564f43ddf515060f457f4ed6c0862250bf90af0dff4",
+  "originHash" : "004283a7666aa08b9e26e1502244d4daebd17a348056bb49cab730594e6e1f85",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "07957602bb99a5355c810187e66e6ce378a1057d",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "jsonschema",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwork-ai/JSONSchema.git",
+      "state" : {
+        "revision" : "1c3b710fb8e65e6a651abda0b32195ff6750d84b",
+        "version" : "1.1.0"
       }
     },
     {


### PR DESCRIPTION
This PR updates iMCP to use our [JSONSchema](https://github.com/loopwork-ai/JSONSchema) package for defining tool input schemas. This cleans up the code and helps ensure that tools have valid, correct interfaces.

Along the way, I also fixed some omissions in existing tool schemas (notably, omitting string format for ISO timestamps), and improved how enumerations are handled for Apple framework types (like `EKReminderPriority`).