### PR TITLE
Add tool annotations

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -771,7 +771,8 @@ actor ServerNetworkManager {
                                 .init(
                                     name: tool.name,
                                     description: tool.description,
-                                    inputSchema: try Value(tool.inputSchema)
+                                    inputSchema: try Value(tool.inputSchema),
+                                    annotations: tool.annotations
                                 )
                             )
                         }

--- a/App/Models/Tool.swift
+++ b/App/Models/Tool.swift
@@ -1,23 +1,26 @@
 import Foundation
+import JSONSchema
 import MCP
 import Ontology
-import JSONSchema
 
 public struct Tool: Sendable {
     let name: String
     let description: String
     let inputSchema: JSONSchema
+    let annotations: MCP.Tool.Annotations
     private let implementation: @Sendable ([String: Value]) async throws -> Value
 
     public init<T: Encodable>(
         name: String,
         description: String,
         inputSchema: JSONSchema,
+        annotations: MCP.Tool.Annotations,
         implementation: @Sendable @escaping ([String: Value]) async throws -> T
     ) {
         self.name = name
         self.description = description
         self.inputSchema = inputSchema
+        self.annotations = annotations
         self.implementation = { input in
             let result = try await implementation(input)
 

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -64,6 +64,11 @@ final class CalendarService: Service {
                     ),
                 ],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Fetch Events",
+                readOnlyHint: true,
+                openWorldHint: false
             )
         ) { arguments in
             guard EKEventStore.authorizationStatus(for: .event) == .fullAccess else {
@@ -195,6 +200,11 @@ final class CalendarService: Service {
                 ],
                 required: ["title", "startDate", "endDate"],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Create Event",
+                destructiveHint: true,
+                openWorldHint: false
             )
         ) { arguments in
             try await self.activate()

--- a/App/Services/Contacts.swift
+++ b/App/Services/Contacts.swift
@@ -73,6 +73,11 @@ final class ContactsService: Service {
             inputSchema: .object(
                 properties: [:],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Who Am I?",
+                readOnlyHint: true,
+                openWorldHint: false
             )
         ) { _ in
             let contact = try self.contactStore.unifiedMeContactWithKeys(toFetch: contactKeys)
@@ -96,6 +101,11 @@ final class ContactsService: Service {
                     ),
                 ],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Search Contacts",
+                readOnlyHint: true,
+                openWorldHint: false
             )
         ) { arguments in
             var predicates: [NSPredicate] = []

--- a/App/Services/Location.swift
+++ b/App/Services/Location.swift
@@ -93,6 +93,11 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
             inputSchema: .object(
                 properties: [:],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Get Current Location",
+                readOnlyHint: true,
+                openWorldHint: false
             )
         ) { _ in
             return try await withCheckedThrowingContinuation {
@@ -176,6 +181,11 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
                 ],
                 required: ["address"],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Geocode Address",
+                readOnlyHint: true,
+                openWorldHint: true
             )
         ) { arguments in
             guard let address = arguments["address"]?.stringValue else {
@@ -264,6 +274,11 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
                     "longitude": .number(),
                 ],
                 required: ["latitude", "longitude"]
+            ),
+            annotations: .init(
+                title: "Reverse Geocode Location",
+                readOnlyHint: true,
+                openWorldHint: true
             )
         ) { arguments in
             guard let latitude = arguments["latitude"]?.doubleValue,

--- a/App/Services/Maps.swift
+++ b/App/Services/Maps.swift
@@ -60,6 +60,11 @@ final class MapsService: NSObject, Service {
                 ],
                 required: ["query"],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Search Places",
+                readOnlyHint: true,
+                openWorldHint: true
             )
         ) { arguments in
             guard let query = arguments["query"]?.stringValue else {
@@ -154,6 +159,11 @@ final class MapsService: NSObject, Service {
                     ),
                 ],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Get Directions",
+                readOnlyHint: true,
+                openWorldHint: true
             )
         ) { arguments in
             // Need either origin address or coordinates
@@ -262,6 +272,11 @@ final class MapsService: NSObject, Service {
                 ],
                 required: ["category", "latitude", "longitude"],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Find Nearby Points of Interest",
+                readOnlyHint: true,
+                openWorldHint: true
             )
         ) { arguments in
             guard let categoryString = arguments["category"]?.stringValue,
@@ -341,6 +356,11 @@ final class MapsService: NSObject, Service {
                     "destinationLongitude",
                 ],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Get Estimated Travel Time",
+                readOnlyHint: true,
+                openWorldHint: true
             )
         ) { arguments in
             guard let originLat = arguments["originLatitude"]?.doubleValue,
@@ -465,6 +485,11 @@ final class MapsService: NSObject, Service {
                 ],
                 required: ["latitude", "longitude", "latitudeDelta", "longitudeDelta"],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Generate Map Image",
+                readOnlyHint: true,
+                openWorldHint: true
             )
         ) { arguments in
             guard let latitude = arguments["latitude"]?.doubleValue,

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -78,6 +78,11 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                     ),
                 ],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Fetch Messages",
+                readOnlyHint: true,
+                openWorldHint: false
             )
         ) { arguments in
             log.debug("Starting message fetch with arguments: \(arguments)")

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -50,6 +50,11 @@ final class RemindersService: Service {
                     ),
                 ],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Fetch Reminders",
+                readOnlyHint: true,
+                openWorldHint: false
             )
         ) { arguments in
             try await self.activate()
@@ -160,6 +165,11 @@ final class RemindersService: Service {
                 ],
                 required: ["title"],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Create Reminder",
+                destructiveHint: true,
+                openWorldHint: false
             )
         ) { arguments in
             try await self.activate()

--- a/App/Services/Utilities.swift
+++ b/App/Services/Utilities.swift
@@ -38,6 +38,11 @@ final class UtilitiesService: Service {
                 ],
                 required: ["sound"],
                 additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Play System Sound",
+                readOnlyHint: true,
+                openWorldHint: false
             )
         ) { input in
             let rawValue = input["sound"]?.stringValue ?? Sound.default.rawValue


### PR DESCRIPTION
New in the latest version of the MCP spec (2025-03-26) is the ability to [annotate tools](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations), for example to denote that a tool is readonly or destructive, or fetches data from the Internet.

This PR adds annotations to all of iMCP's existing tools. This doesn't change the behavior of tools, but instead provides additional context that may change how some clients interact with iMCP.