### PR TITLE
Make ISO 8601 date parsing more flexible

### DIFF
--- a/App/Extensions/Foundation+Extensions.swift
+++ b/App/Extensions/Foundation+Extensions.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension ISO8601DateFormatter {
+    /// Attempts to parse a date string using several common ISO 8601 format options.
+    /// - Parameters:
+    ///   - dateString: The string representation of the date.
+    /// - Returns: A `Date` object if parsing is successful with any format, otherwise `nil`.
+    static func parseFlexibleISODate(_ dateString: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+
+        let optionsToTry: [ISO8601DateFormatter.Options] = [
+            [.withInternetDateTime, .withFractionalSeconds],  // Handles yyyy-MM-dd\'T\'HH:mm:ss.SSSZ and yyyy-MM-dd\'T\'HH:mm:ss.SSSZZZZZ
+            [.withInternetDateTime],  // Handles yyyy-MM-dd\'T\'HH:mm:ssZ and yyyy-MM-dd\'T\'HH:mm:ssZZZZZ
+            [.withFullDate, .withFullTime, .withFractionalSeconds],  // Handles yyyy-MM-dd\'T\'HH:mm:ss.SSS (no Z or offset)
+            [.withFullDate, .withFullTime],  // Handles yyyy-MM-dd\'T\'HH:mm:ss (no Z or offset)
+            [.withFullDate, .withFullTime, .withSpaceBetweenDateAndTime, .withFractionalSeconds],  // Handles yyyy-MM-dd HH:mm:ss.SSSZZZZZ etc.
+            [.withFullDate, .withFullTime, .withSpaceBetweenDateAndTime],  // Handles yyyy-MM-dd HH:mm:ssZZZZZ etc.
+        ]
+
+        for options in optionsToTry {
+            formatter.formatOptions = options
+            if let date = formatter.date(from: dateString) {
+                return date
+            }
+        }
+
+        return nil
+    }
+}

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -89,21 +89,18 @@ final class CalendarService: Service {
             }
 
             // Parse dates and set defaults
-            let dateFormatter = ISO8601DateFormatter()
-            dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
             let now = Date()
             var startDate = now
             var endDate = Calendar.current.date(byAdding: .weekOfYear, value: 1, to: now)!
 
             if case let .string(start) = arguments["startDate"],
-                let parsedStart = dateFormatter.date(from: start)
+                let parsedStart = ISO8601DateFormatter.parseFlexibleISODate(start)
             {
                 startDate = parsedStart
             }
 
             if case let .string(end) = arguments["endDate"],
-                let parsedEnd = dateFormatter.date(from: end)
+                let parsedEnd = ISO8601DateFormatter.parseFlexibleISODate(end)
             {
                 endDate = parsedEnd
             }
@@ -230,17 +227,17 @@ final class CalendarService: Service {
             event.title = title
 
             // Parse dates
-            let dateFormatter = ISO8601DateFormatter()
-            dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
             guard case let .string(startDateStr) = arguments["startDate"],
-                let startDate = dateFormatter.date(from: startDateStr),
+                let startDate = ISO8601DateFormatter.parseFlexibleISODate(startDateStr),
                 case let .string(endDateStr) = arguments["endDate"],
-                let endDate = dateFormatter.date(from: endDateStr)
+                let endDate = ISO8601DateFormatter.parseFlexibleISODate(endDateStr)
             else {
                 throw NSError(
                     domain: "CalendarError", code: 2,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid start or end date format"]
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Invalid start or end date format. Expected ISO 8601 format."
+                    ]
                 )
             }
 

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -96,8 +96,8 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
             var dateRange: Range<Date>?
             if let startDateStr = arguments["startDate"]?.stringValue,
                 let endDateStr = arguments["endDate"]?.stringValue,
-                let startDate = ISO8601DateFormatter().date(from: startDateStr),
-                let endDate = ISO8601DateFormatter().date(from: endDateStr)
+                let startDate = ISO8601DateFormatter.parseFlexibleISODate(startDateStr),
+                let endDate = ISO8601DateFormatter.parseFlexibleISODate(endDateStr)
             {
                 dateRange = startDate..<endDate
             }

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -80,15 +80,14 @@ final class RemindersService: Service {
             }
 
             // Parse dates if provided
-            let dateFormatter = ISO8601DateFormatter()
             var startDate: Date? = nil
             var endDate: Date? = nil
 
             if case let .string(start) = arguments["startDate"] {
-                startDate = dateFormatter.date(from: start)
+                startDate = ISO8601DateFormatter.parseFlexibleISODate(start)
             }
             if case let .string(end) = arguments["endDate"] {
-                endDate = dateFormatter.date(from: end)
+                endDate = ISO8601DateFormatter.parseFlexibleISODate(end)
             }
 
             // Create predicate based on completion status
@@ -206,7 +205,7 @@ final class RemindersService: Service {
 
             // Set optional properties
             if case let .string(dueDateStr) = arguments["dueDate"],
-                let dueDate = ISO8601DateFormatter().date(from: dueDateStr)
+                let dueDate = ISO8601DateFormatter.parseFlexibleISODate(dueDateStr)
             {
                 reminder.dueDateComponents = Calendar.current.dateComponents(
                     [.year, .month, .day, .hour, .minute, .second], from: dueDate)


### PR DESCRIPTION
I noticed that some tool calls were failing because the model was providing timestamps that `ISO8601DateFormatter` didn't like. In this case, the problem was omitting fractional seconds, but in general, we should be a lot more flexible about accepting reasonable values.

This PR introduces an extension on that class to try a bunch of different formats and pick the first one that works. With these changes, I haven't seen tool use fail because of timestamp format pedantry.