### PR TITLE
Fix list of available values for point of interest categories in `generateMapImage` tool

### DIFF
--- a/App/Services/Maps.swift
+++ b/App/Services/Maps.swift
@@ -472,10 +472,12 @@ final class MapsService: NSObject, Service {
                                 description:
                                     "Show specific types of points of interest to show; select as many as you're interested in",
                                 items: .anyOf(
-                                    MKPointOfInterestCategory.allCases.map { .string(const: .string($0.rawValue)) }
+                                    MKPointOfInterestCategory.allCases.map {
+                                        .string(const: .string($0.stringValue))
+                                    }
                                 ),
                                 minItems: 1
-                            )
+                            ),
                         ]
                     ),
                     "showBuildings": .boolean(


### PR DESCRIPTION
Currently, we're using `rawValue` instead of `stringValue`, so these are showing up in schema as `"MKPOICategoryAirport"` instead of `"airport"`.