### PR TITLE
Rename tools to adopt `{namespace}.{function}` convention

### DIFF
--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -22,7 +22,7 @@ final class CalendarService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "fetchEvents",
+            name: "events.fetch",
             description: "Get events from the calendar with flexible filtering options",
             inputSchema: .object(
                 properties: [
@@ -152,7 +152,7 @@ final class CalendarService: Service {
             return events.map { Event($0) }
         }
         Tool(
-            name: "createEvent",
+            name: "events.create",
             description: "Create a new calendar event with specified properties",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Contacts.swift
+++ b/App/Services/Contacts.swift
@@ -67,7 +67,7 @@ final class ContactsService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "whoami",
+            name: "contacts.me",
             description:
                 "Get contact information about the user, including name, phone number, email, birthday, relations, address, online presence, and occupation. Always run this tool when the user asks a question that requires personal information about themselves.",
             inputSchema: .object(
@@ -85,7 +85,7 @@ final class ContactsService: Service {
         }
 
         Tool(
-            name: "searchContacts",
+            name: "contacts.search",
             description:
                 "Search contacts by name, phone number, and/or email. Provide only the parameters you want to search by. Provide at least one parameter.",
             inputSchema: .object(

--- a/App/Services/Location.swift
+++ b/App/Services/Location.swift
@@ -88,7 +88,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
 
     var tools: [Tool] {
         Tool(
-            name: "getCurrentLocation",
+            name: "location.current",
             description: "Get the user's current location",
             inputSchema: .object(
                 properties: [:],
@@ -171,7 +171,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
         }
 
         Tool(
-            name: "geocodeAddress",
+            name: "location.geocode",
             description: "Convert an address to geographic coordinates",
             inputSchema: .object(
                 properties: [
@@ -266,7 +266,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
         }
 
         Tool(
-            name: "reverseGeocode",
+            name: "location.reverse-geocode",
             description: "Convert geographic coordinates to an address",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Maps.swift
+++ b/App/Services/Maps.swift
@@ -37,7 +37,7 @@ final class MapsService: NSObject, Service {
 
     var tools: [Tool] {
         Tool(
-            name: "searchPlaces",
+            name: "maps.search",
             description: "Search for places, addresses, points of interest by text query",
             inputSchema: .object(
                 properties: [
@@ -124,7 +124,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "getDirections",
+            name: "maps.directions",
             description: "Get directions between two locations with optional transport type",
             inputSchema: .object(
                 properties: [
@@ -251,7 +251,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "findNearbyPointsOfInterest",
+            name: "maps.explore",
             description: "Find points of interest near a location",
             inputSchema: .object(
                 properties: [
@@ -337,7 +337,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "getETABetweenLocations",
+            name: "maps.eta",
             description: "Calculate estimated travel time between two locations",
             inputSchema: .object(
                 properties: [
@@ -437,7 +437,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "generateMapImage",
+            name: "maps.generate",
             description: "Generate a static map image for given coordinates and parameters",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -50,7 +50,7 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
 
     var tools: [Tool] {
         Tool(
-            name: "fetchMessages",
+            name: "messages.fetch",
             description: "Fetch messages from the Messages app",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -22,7 +22,7 @@ final class RemindersService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "fetchReminders",
+            name: "reminders.fetch",
             description: "Get reminders from the reminders app with flexible filtering options",
             inputSchema: .object(
                 properties: [
@@ -134,7 +134,7 @@ final class RemindersService: Service {
         }
 
         Tool(
-            name: "createReminder",
+            name: "reminders.create",
             description: "Create a new reminder with specified properties",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Utilities.swift
+++ b/App/Services/Utilities.swift
@@ -1,6 +1,6 @@
 import AppKit
-import OSLog
 import JSONSchema
+import OSLog
 
 private let log = Logger.service("utilities")
 
@@ -28,7 +28,7 @@ final class UtilitiesService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "playSystemSound",
+            name: "utilities.beep",
             description: "Play a system sound. Only call if the user explicitly asks for it.",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Weather.swift
+++ b/App/Services/Weather.swift
@@ -13,7 +13,7 @@ final class WeatherService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "getCurrentWeatherForLocation",
+            name: "weather.current",
             description:
                 "Get current weather for a location, including temperature, conditions, humidity, and wind speed",
             inputSchema: .object(
@@ -51,7 +51,7 @@ final class WeatherService: Service {
         }
 
         Tool(
-            name: "getDailyForecastForLocation",
+            name: "weather.daily",
             description: "Get daily weather forecast for a location",
             inputSchema: .object(
                 properties: [
@@ -100,9 +100,9 @@ final class WeatherService: Service {
 
             return dailyForecast.prefix(days).map { WeatherForecast($0) }
         }
-        
+
         Tool(
-            name: "getHourlyForecastForLocation",
+            name: "weather.hourly",
             description: "Get hourly weather forecast for a location",
             inputSchema: .object(
                 properties: [
@@ -155,7 +155,7 @@ final class WeatherService: Service {
         }
 
         Tool(
-            name: "getMinuteByMinuteForecastForLocation",
+            name: "weather.minute",
             description: "Get minute-by-minute weather forecast for a location",
             inputSchema: .object(
                 properties: [


### PR DESCRIPTION
Currently, iMCP tools are named in `dromedaryCase`. It's all the same to the AI, but to a user trying to make sense of tools presented in a client, grouping tool names by function makes for a better experience.

| Service | Before | After |
|---------|---------|--------|
| Calendar | `createEvent` | `events.create` |
| Calendar | `fetchEvents` | `events.fetch` |
| Contacts | `searchContacts` | `contacts.search` |
| Contacts | `whoami` | `contacts.me` |
| Location | `getCurrentLocation` | `location.current` |
| Location | `geocodeAddress` | `location.geocode` |
| Location | `reverseGeocode` | `location.reverse-geocode` |
| Maps | `findNearbyPointsOfInterest` | `maps.explore` |
| Maps | `generateMapImage` | `maps.generate` |
| Maps | `getDirections` | `maps.directions` |
| Maps | `getETABetweenLocations` | `maps.eta` |
| Maps | `searchPlaces` | `maps.search` |
| Messages | `fetchMessages` | `messages.fetch` |
| Reminders | `createReminder` | `reminders.create` |
| Reminders | `fetchReminders` | `reminders.fetch` |
| Weather | `getCurrentWeatherForLocation` | `weather.current` |
| Weather | `getDailyForecastForLocation` | `weather.daily` |
| Weather | `getHourlyForecastForLocation` | `weather.hourly` |
| Weather | `getMinuteByMinuteForecastForLocation` | `weather.minute` |