### PR TITLE
Make input schemas more concise

### DIFF
--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -39,7 +39,7 @@ final class CalendarService: Service {
                             "Names of calendars to fetch from; if empty, fetches from all calendars",
                         items: .string(),
                     ),
-                    "searchText": .string(
+                    "query": .string(
                         description: "Text to search for in event titles and locations"
                     ),
                     "includeAllDay": .boolean(
@@ -115,7 +115,7 @@ final class CalendarService: Service {
                 events = events.filter { !$0.isAllDay }
             }
 
-            if case let .string(searchText) = arguments["searchText"],
+            if case let .string(searchText) = arguments["query"],
                 !searchText.isEmpty
             {
                 events = events.filter {

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -26,11 +26,11 @@ final class CalendarService: Service {
             description: "Get events from the calendar with flexible filtering options",
             inputSchema: .object(
                 properties: [
-                    "startDate": .string(
+                    "start": .string(
                         description: "Start date of the range (defaults to now)",
                         format: .dateTime
                     ),
-                    "endDate": .string(
+                    "end": .string(
                         description: "End date of the range (defaults to one week from start)",
                         format: .dateTime
                     ),
@@ -86,13 +86,13 @@ final class CalendarService: Service {
             var startDate = now
             var endDate = Calendar.current.date(byAdding: .weekOfYear, value: 1, to: now)!
 
-            if case let .string(start) = arguments["startDate"],
+            if case let .string(start) = arguments["start"],
                 let parsedStart = ISO8601DateFormatter.parseFlexibleISODate(start)
             {
                 startDate = parsedStart
             }
 
-            if case let .string(end) = arguments["endDate"],
+            if case let .string(end) = arguments["end"],
                 let parsedEnd = ISO8601DateFormatter.parseFlexibleISODate(end)
             {
                 endDate = parsedEnd
@@ -150,10 +150,10 @@ final class CalendarService: Service {
             inputSchema: .object(
                 properties: [
                     "title": .string(),
-                    "startDate": .string(
+                    "start": .string(
                         format: .dateTime
                     ),
-                    "endDate": .string(
+                    "end": .string(
                         format: .dateTime
                     ),
                     "calendar": .string(
@@ -179,7 +179,7 @@ final class CalendarService: Service {
                     "hasAlarms": .boolean(),
                     "isRecurring": .boolean(),
                 ],
-                required: ["title", "startDate", "endDate"],
+                required: ["title", "start", "end"],
                 additionalProperties: false
             ),
             annotations: .init(
@@ -211,9 +211,9 @@ final class CalendarService: Service {
             event.title = title
 
             // Parse dates
-            guard case let .string(startDateStr) = arguments["startDate"],
+            guard case let .string(startDateStr) = arguments["start"],
                 let startDate = ISO8601DateFormatter.parseFlexibleISODate(startDateStr),
-                case let .string(endDateStr) = arguments["endDate"],
+                case let .string(endDateStr) = arguments["end"],
                 let endDate = ISO8601DateFormatter.parseFlexibleISODate(endDateStr)
             else {
                 throw NSError(

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -34,7 +34,7 @@ final class CalendarService: Service {
                         description: "End date of the range (defaults to one week from start)",
                         format: .dateTime
                     ),
-                    "calendarNames": .array(
+                    "calendars": .array(
                         description:
                             "Names of calendars to fetch from; if empty, fetches from all calendars",
                         items: .string(),
@@ -74,7 +74,7 @@ final class CalendarService: Service {
 
             // Filter calendars based on provided names
             var calendars = self.eventStore.calendars(for: .event)
-            if case let .array(calendarNames) = arguments["calendarNames"],
+            if case let .array(calendarNames) = arguments["calendars"],
                 !calendarNames.isEmpty
             {
                 let requestedNames = Set(calendarNames.compactMap { $0.stringValue?.lowercased() })
@@ -156,7 +156,7 @@ final class CalendarService: Service {
                     "endDate": .string(
                         format: .dateTime
                     ),
-                    "calendarName": .string(
+                    "calendar": .string(
                         description: "Calendar to use (uses default if not specified)"
                     ),
                     "location": .string(),
@@ -249,7 +249,7 @@ final class CalendarService: Service {
 
             // Set calendar
             var calendar = self.eventStore.defaultCalendarForNewEvents
-            if case let .string(calendarName) = arguments["calendarName"] {
+            if case let .string(calendarName) = arguments["calendar"] {
                 if let matchingCalendar = self.eventStore.calendars(for: .event)
                     .first(where: { $0.title.lowercased() == calendarName.lowercased() })
                 {

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -27,25 +27,22 @@ final class CalendarService: Service {
             inputSchema: .object(
                 properties: [
                     "startDate": .string(
-                        description:
-                            "The start of the date range (defaults to now if not specified)",
+                        description: "Start date of the range (defaults to now)",
                         format: .dateTime
                     ),
                     "endDate": .string(
-                        description:
-                            "The end of the date range (defaults to one week from start if not specified)",
+                        description: "End date of the range (defaults to one week from start)",
                         format: .dateTime
                     ),
                     "calendarNames": .array(
                         description:
-                            "Names of calendars to fetch from. If empty or not specified, fetches from all calendars.",
+                            "Names of calendars to fetch from; if empty, fetches from all calendars",
                         items: .string(),
                     ),
                     "searchText": .string(
                         description: "Text to search for in event titles and locations"
                     ),
                     "includeAllDay": .boolean(
-                        description: "Whether to include all-day events",
                         default: true
                     ),
                     "status": .string(
@@ -56,12 +53,8 @@ final class CalendarService: Service {
                         description: "Filter by availability status",
                         enum: EKEventAvailability.allCases.map { .string($0.stringValue) }
                     ),
-                    "hasAlarms": .boolean(
-                        description: "Filter for events that have alarms/reminders set"
-                    ),
-                    "isRecurring": .boolean(
-                        description: "Filter for recurring/non-recurring events"
-                    ),
+                    "hasAlarms": .boolean(),
+                    "isRecurring": .boolean(),
                 ],
                 additionalProperties: false
             ),
@@ -156,44 +149,37 @@ final class CalendarService: Service {
             description: "Create a new calendar event with specified properties",
             inputSchema: .object(
                 properties: [
-                    "title": .string(
-                        description: "The title of the event"
-                    ),
+                    "title": .string(),
                     "startDate": .string(
-                        description: "The start of the event",
+                        description: "Event start time",
                         format: .dateTime
                     ),
                     "endDate": .string(
-                        description: "The end of the event",
+                        description: "Event end time",
                         format: .dateTime
                     ),
                     "calendarName": .string(
-                        description:
-                            "Name of the calendar to create the event in (uses default calendar if not specified)"
+                        description: "Calendar to use (uses default if not specified)"
                     ),
-                    "location": .string(
-                        description: "Location of the event"
-                    ),
-                    "notes": .string(
-                        description: "Notes or description for the event"
-                    ),
+                    "location": .string(),
+                    "notes": .string(),
                     "url": .string(
-                        description: "URL associated with the event (e.g., meeting link)",
                         format: .uri
                     ),
                     "isAllDay": .boolean(
-                        description: "Whether this is an all-day event",
                         default: false
                     ),
                     "availability": .string(
-                        description: "Event availability status",
+                        description: "Availability status",
                         default: .string(EKEventAvailability.busy.stringValue),
                         enum: EKEventAvailability.allCases.map { .string($0.stringValue) }
                     ),
                     "alarms": .array(
-                        description: "Array of minutes before the event to set alarms",
+                        description: "Minutes before event to set alarms",
                         items: .integer()
                     ),
+                    "hasAlarms": .boolean(),
+                    "isRecurring": .boolean(),
                 ],
                 required: ["title", "startDate", "endDate"],
                 additionalProperties: false

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -151,11 +151,9 @@ final class CalendarService: Service {
                 properties: [
                     "title": .string(),
                     "startDate": .string(
-                        description: "Event start time",
                         format: .dateTime
                     ),
                     "endDate": .string(
-                        description: "Event end time",
                         format: .dateTime
                     ),
                     "calendarName": .string(

--- a/App/Services/Contacts.swift
+++ b/App/Services/Contacts.swift
@@ -87,17 +87,17 @@ final class ContactsService: Service {
         Tool(
             name: "contacts.search",
             description:
-                "Search contacts by name, phone number, and/or email. Provide only the parameters you want to search by. Provide at least one parameter.",
+                "Search contacts by name, phone number, and/or email",
             inputSchema: .object(
                 properties: [
                     "name": .string(
-                        description: "Name to search for (will match given name or family name)"
+                        description: "Name to search for"
                     ),
                     "phone": .string(
-                        description: "Phone number to search for (any formatting accepted)"
+                        description: "Phone number to search for"
                     ),
                     "email": .string(
-                        description: "Email address to search for (case insensitive)"
+                        description: "Email address to search for"
                     ),
                 ],
                 additionalProperties: false

--- a/App/Services/Location.swift
+++ b/App/Services/Location.swift
@@ -176,7 +176,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
             inputSchema: .object(
                 properties: [
                     "address": .string(
-                        description: "The address to geocode"
+                        description: "Address to geocode"
                     )
                 ],
                 required: ["address"],

--- a/App/Services/Maps.swift
+++ b/App/Services/Maps.swift
@@ -42,10 +42,10 @@ final class MapsService: NSObject, Service {
             inputSchema: .object(
                 properties: [
                     "query": .string(
-                        description: "The search text (place name, address, etc.)"
+                        description: "Search text (place name, address, etc.)"
                     ),
                     "region": .object(
-                        description: "Optional region to bias search results",
+                        description: "Region to bias search results",
                         properties: [
                             "latitude": .number(),
                             "longitude": .number(),
@@ -129,7 +129,7 @@ final class MapsService: NSObject, Service {
             inputSchema: .object(
                 properties: [
                     "originAddress": .string(
-                        description: "Origin address as text"
+                        description: "Origin address"
                     ),
                     "originCoordinates": .object(
                         description: "Origin coordinates",
@@ -141,7 +141,7 @@ final class MapsService: NSObject, Service {
                         additionalProperties: false
                     ),
                     "destinationAddress": .string(
-                        description: "Destination address as text"
+                        description: "Destination address"
                     ),
                     "destinationCoordinates": .object(
                         description: "Destination coordinates",
@@ -153,7 +153,7 @@ final class MapsService: NSObject, Service {
                         additionalProperties: false
                     ),
                     "transportType": .string(
-                        description: "Type of transportation (automobile, walking, transit, any)",
+                        description: "Transport type",
                         default: "automobile",
                         enum: ["automobile", "walking", "transit", "any"]
                     ),
@@ -256,7 +256,7 @@ final class MapsService: NSObject, Service {
             inputSchema: .object(
                 properties: [
                     "category": .string(
-                        description: "Category of points of interest",
+                        description: "POI category",
                         enum: MKPointOfInterestCategory.allCases.map { .string($0.stringValue) }
                     ),
                     "latitude": .number(),
@@ -266,7 +266,7 @@ final class MapsService: NSObject, Service {
                         default: .double(defaultSearchRadius)
                     ),
                     "limit": .integer(
-                        description: "Maximum number of results to return",
+                        description: "Maximum results to return",
                         default: .int(defaultSearchLimit)
                     ),
                 ],
@@ -346,7 +346,7 @@ final class MapsService: NSObject, Service {
                     "destinationLatitude": .number(),
                     "destinationLongitude": .number(),
                     "transportType": .string(
-                        description: "Type of transportation (automobile, walking, transit)",
+                        description: "Transport type",
                         default: "automobile",
                         enum: ["automobile", "walking", "transit"]
                     ),
@@ -444,33 +444,32 @@ final class MapsService: NSObject, Service {
                     "latitude": .number(),
                     "longitude": .number(),
                     "latitudeDelta": .number(
-                        description: "Amount of latitude degrees to be visible on the map"
+                        description: "Latitude degrees visible on map"
                     ),
                     "longitudeDelta": .number(
-                        description: "Amount of longitude degrees to be visible on the map"
+                        description: "Longitude degrees visible on map"
                     ),
                     "width": .integer(
-                        description: "Width of the desired map image in pixels",
+                        description: "Image width in pixels",
                         default: .int(Int(defaultMapImageSize.width))
                     ),
                     "height": .integer(
-                        description: "Height of the desired map image in pixels",
+                        description: "Image height in pixels",
                         default: .int(Int(defaultMapImageSize.height))
                     ),
                     "mapType": .string(
-                        description: "Type of map (standard, satellite, hybrid, mutedStandard)",
+                        description: "Map type",
                         default: "standard",
                         enum: ["standard", "satellite", "hybrid", "mutedStandard"]
                     ),
                     "showPointsOfInterest": .oneOf(
                         [
                             .boolean(
-                                description: "Show all (true) or no (false) points of interest",
+                                description: "Show all (true) or no (false) POIs",
                                 default: false
                             ),
                             .array(
-                                description:
-                                    "Show specific types of points of interest to show; select as many as you're interested in",
+                                description: "Specific POI types to show",
                                 items: .anyOf(
                                     MKPointOfInterestCategory.allCases.map {
                                         .string(const: .string($0.stringValue))
@@ -481,7 +480,7 @@ final class MapsService: NSObject, Service {
                         ]
                     ),
                     "showBuildings": .boolean(
-                        description: "Whether to show buildings on the map",
+                        description: "Whether to show buildings",
                         default: false
                     ),
                 ],

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -56,24 +56,20 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                 properties: [
                     "participants": .array(
                         description:
-                            "A list of participant handles. May be a phone number or email address. Phone numbers should be in E.164 format (leading + and country code, no spaces or punctuation).",
+                            "Participant handles (phone or email). Phone numbers should use E.164 format",
                         items: .string()
                     ),
                     "startDate": .string(
-                        description:
-                            "ISO 8601 formatted date-time string for the start of the date range (inclusive)",
+                        description: "Start of the date range (inclusive)",
                         format: .dateTime
                     ),
                     "endDate": .string(
-                        description:
-                            "ISO 8601 formatted date-time string for the end of the date range (exclusive)",
+                        description: "End of the date range (exclusive)",
                         format: .dateTime
                     ),
-                    "searchTerm": .string(
-                        description: "Search term to filter messages by"
-                    ),
+                    "searchTerm": .string(),
                     "limit": .integer(
-                        description: "Maximum number of messages to return",
+                        description: "Maximum messages to return",
                         default: .int(defaultLimit)
                     ),
                 ],

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -59,11 +59,11 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                             "Participant handles (phone or email). Phone numbers should use E.164 format",
                         items: .string()
                     ),
-                    "startDate": .string(
+                    "start": .string(
                         description: "Start of the date range (inclusive)",
                         format: .dateTime
                     ),
-                    "endDate": .string(
+                    "end": .string(
                         description: "End of the date range (exclusive)",
                         format: .dateTime
                     ),
@@ -90,8 +90,8 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                 }) ?? []
 
             var dateRange: Range<Date>?
-            if let startDateStr = arguments["startDate"]?.stringValue,
-                let endDateStr = arguments["endDate"]?.stringValue,
+            if let startDateStr = arguments["start"]?.stringValue,
+                let endDateStr = arguments["end"]?.stringValue,
                 let startDate = ISO8601DateFormatter.parseFlexibleISODate(startDateStr),
                 let endDate = ISO8601DateFormatter.parseFlexibleISODate(endDateStr)
             {

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -67,7 +67,9 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                         description: "End of the date range (exclusive)",
                         format: .dateTime
                     ),
-                    "searchTerm": .string(),
+                    "query": .string(
+                        description: "Search term to filter messages by content"
+                    ),
                     "limit": .integer(
                         description: "Maximum messages to return",
                         default: .int(defaultLimit)
@@ -98,7 +100,7 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                 dateRange = startDate..<endDate
             }
 
-            let searchTerm = arguments["searchTerm"]?.stringValue
+            let searchTerm = arguments["query"]?.stringValue
             let limit = arguments["limit"]?.intValue
 
             let db = try self.createDatabaseConnection()

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -138,7 +138,6 @@ final class RemindersService: Service {
                 properties: [
                     "title": .string(),
                     "dueDate": .string(
-                        description: "Due date of the reminder",
                         format: .dateTime
                     ),
                     "listName": .string(
@@ -146,7 +145,6 @@ final class RemindersService: Service {
                     ),
                     "notes": .string(),
                     "priority": .string(
-                        description: "Priority level",
                         default: .string(EKReminderPriority.none.stringValue),
                         enum: EKReminderPriority.allCases.map { .string($0.stringValue) }
                     ),

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -137,7 +137,7 @@ final class RemindersService: Service {
             inputSchema: .object(
                 properties: [
                     "title": .string(),
-                    "dueDate": .string(
+                    "due": .string(
                         format: .dateTime
                     ),
                     "list": .string(
@@ -195,7 +195,7 @@ final class RemindersService: Service {
             reminder.calendar = calendar
 
             // Set optional properties
-            if case let .string(dueDateStr) = arguments["dueDate"],
+            if case let .string(dueDateStr) = arguments["due"],
                 let dueDate = ISO8601DateFormatter.parseFlexibleISODate(dueDateStr)
             {
                 reminder.dueDateComponents = Calendar.current.dateComponents(

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -38,7 +38,7 @@ final class RemindersService: Service {
                         description: "End date range for fetching reminders",
                         format: .dateTime
                     ),
-                    "listNames": .array(
+                    "lists": .array(
                         description:
                             "Names of reminder lists to fetch from; if empty, fetches from all lists",
                         items: .string()
@@ -67,7 +67,7 @@ final class RemindersService: Service {
 
             // Filter reminder lists based on provided names
             var reminderLists = self.eventStore.calendars(for: .reminder)
-            if case let .array(listNames) = arguments["listNames"],
+            if case let .array(listNames) = arguments["lists"],
                 !listNames.isEmpty
             {
                 let requestedNames = Set(

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -140,7 +140,7 @@ final class RemindersService: Service {
                     "dueDate": .string(
                         format: .dateTime
                     ),
-                    "listName": .string(
+                    "list": .string(
                         description: "Reminder list name (uses default if not specified)"
                     ),
                     "notes": .string(),
@@ -185,7 +185,7 @@ final class RemindersService: Service {
 
             // Set calendar (list)
             var calendar = self.eventStore.defaultCalendarForNewReminders()
-            if case let .string(listName) = arguments["listName"] {
+            if case let .string(listName) = arguments["list"] {
                 if let matchingCalendar = self.eventStore.calendars(for: .reminder)
                     .first(where: { $0.title.lowercased() == listName.lowercased() })
                 {

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -30,11 +30,11 @@ final class RemindersService: Service {
                         description:
                             "If true, fetch completed reminders; if false, fetch incomplete; if omitted, fetch all"
                     ),
-                    "startDate": .string(
+                    "start": .string(
                         description: "Start date range for fetching reminders",
                         format: .dateTime
                     ),
-                    "endDate": .string(
+                    "end": .string(
                         description: "End date range for fetching reminders",
                         format: .dateTime
                     ),
@@ -81,10 +81,10 @@ final class RemindersService: Service {
             var startDate: Date? = nil
             var endDate: Date? = nil
 
-            if case let .string(start) = arguments["startDate"] {
+            if case let .string(start) = arguments["start"] {
                 startDate = ISO8601DateFormatter.parseFlexibleISODate(start)
             }
-            if case let .string(end) = arguments["endDate"] {
+            if case let .string(end) = arguments["end"] {
                 endDate = ISO8601DateFormatter.parseFlexibleISODate(end)
             }
 

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -28,21 +28,19 @@ final class RemindersService: Service {
                 properties: [
                     "completed": .boolean(
                         description:
-                            "If true, fetch completed reminders. If false, fetch incomplete reminders. If not specified, fetch all reminders."
+                            "If true, fetch completed reminders; if false, fetch incomplete; if omitted, fetch all"
                     ),
                     "startDate": .string(
-                        description:
-                            "The start of the date range to fetch reminders from",
+                        description: "Start date range for fetching reminders",
                         format: .dateTime
                     ),
                     "endDate": .string(
-                        description:
-                            "The end of the date range to fetch reminders from",
+                        description: "End date range for fetching reminders",
                         format: .dateTime
                     ),
                     "listNames": .array(
                         description:
-                            "Names of reminder lists to fetch from. If empty or not specified, fetches from all lists.",
+                            "Names of reminder lists to fetch from; if empty, fetches from all lists",
                         items: .string()
                     ),
                     "searchText": .string(
@@ -138,27 +136,22 @@ final class RemindersService: Service {
             description: "Create a new reminder with specified properties",
             inputSchema: .object(
                 properties: [
-                    "title": .string(
-                        description: "The title of the reminder"
-                    ),
+                    "title": .string(),
                     "dueDate": .string(
-                        description: "The due date of the reminder",
+                        description: "Due date of the reminder",
                         format: .dateTime
                     ),
                     "listName": .string(
-                        description:
-                            "Name of the reminder list to add the reminder to (uses default if not specified)"
+                        description: "Reminder list name (uses default if not specified)"
                     ),
-                    "notes": .string(
-                        description: "Additional notes for the reminder"
-                    ),
+                    "notes": .string(),
                     "priority": .string(
-                        description: "The priority of the reminder",
+                        description: "Priority level",
                         default: .string(EKReminderPriority.none.stringValue),
                         enum: EKReminderPriority.allCases.map { .string($0.stringValue) }
                     ),
                     "alarms": .array(
-                        description: "The minutes before the due date to set alarms",
+                        description: "Minutes before due date to set alarms",
                         items: .integer()
                     ),
                 ],

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -43,7 +43,7 @@ final class RemindersService: Service {
                             "Names of reminder lists to fetch from; if empty, fetches from all lists",
                         items: .string()
                     ),
-                    "searchText": .string(
+                    "query": .string(
                         description: "Text to search for in reminder titles"
                     ),
                 ],
@@ -120,7 +120,7 @@ final class RemindersService: Service {
             var filteredReminders = reminders
 
             // Filter by search text if provided
-            if case let .string(searchText) = arguments["searchText"],
+            if case let .string(searchText) = arguments["query"],
                 !searchText.isEmpty
             {
                 filteredReminders = filteredReminders.filter {

--- a/App/Services/Utilities.swift
+++ b/App/Services/Utilities.swift
@@ -29,7 +29,7 @@ final class UtilitiesService: Service {
     var tools: [Tool] {
         Tool(
             name: "utilities.beep",
-            description: "Play a system sound. Only call if the user explicitly asks for it.",
+            description: "Play a system sound",
             inputSchema: .object(
                 properties: [
                     "sound": .string(

--- a/App/Services/Weather.swift
+++ b/App/Services/Weather.swift
@@ -15,15 +15,11 @@ final class WeatherService: Service {
         Tool(
             name: "weather.current",
             description:
-                "Get current weather for a location, including temperature, conditions, humidity, and wind speed",
+                "Get current weather for a location",
             inputSchema: .object(
                 properties: [
-                    "latitude": .number(
-                        description: "The latitude of the location"
-                    ),
-                    "longitude": .number(
-                        description: "The longitude of the location"
-                    ),
+                    "latitude": .number(),
+                    "longitude": .number(),
                 ],
                 additionalProperties: false
             ),
@@ -55,14 +51,10 @@ final class WeatherService: Service {
             description: "Get daily weather forecast for a location",
             inputSchema: .object(
                 properties: [
-                    "latitude": .number(
-                        description: "The latitude of the location"
-                    ),
-                    "longitude": .number(
-                        description: "The longitude of the location"
-                    ),
+                    "latitude": .number(),
+                    "longitude": .number(),
                     "days": .integer(
-                        description: "Number of days to forecast (default 7, max 10)",
+                        description: "Number of forecast days (max 10)",
                         default: 7,
                         minimum: 1,
                         maximum: 10
@@ -106,12 +98,8 @@ final class WeatherService: Service {
             description: "Get hourly weather forecast for a location",
             inputSchema: .object(
                 properties: [
-                    "latitude": .number(
-                        description: "The latitude of the location"
-                    ),
-                    "longitude": .number(
-                        description: "The longitude of the location"
-                    ),
+                    "latitude": .number(),
+                    "longitude": .number(),
                     "hours": .integer(
                         description: "Number of hours to forecast",
                         default: 24,
@@ -159,14 +147,10 @@ final class WeatherService: Service {
             description: "Get minute-by-minute weather forecast for a location",
             inputSchema: .object(
                 properties: [
-                    "latitude": .number(
-                        description: "The latitude of the location"
-                    ),
-                    "longitude": .number(
-                        description: "The longitude of the location"
-                    ),
+                    "latitude": .number(),
+                    "longitude": .number(),
                     "minutes": .integer(
-                        description: "Number of minutes to forecast (default 60)",
+                        description: "Number of minutes to forecast",
                         default: 60,
                         minimum: 1,
                         maximum: 120


### PR DESCRIPTION
One of my pet peeves is documentation that just repeats the name of the symbol. Gosh, how it grinds my gears 😡 

And yet, we're doing plenty of that now with iMCP. Mea culpa. 

But it's not merely annoying, it's wasteful. We're paying for all of those extra tokens each time we make a request, and that really adds up.

This PR aims to trim the fat, rewording to make tool and parameter descriptions more concise, and removing them if they're self-explanatory (e.g. `longitude` in a `maps.explore` tool).

---

## `tools/list` formatted JSON responses

```shell
wc before.json 
     868    2079   35163 before.JSON

wc after.json 
     852    1775   32307 after.JSON
```

This optimization reduces the response by 8.1% (2,856 characters), or about 700-750 fewer tokens. Pretty good!