### PR TITLE
Replace periods in tool names with underscores

### DIFF
--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -22,7 +22,7 @@ final class CalendarService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "events.fetch",
+            name: "events_fetch",
             description: "Get events from the calendar with flexible filtering options",
             inputSchema: .object(
                 properties: [
@@ -145,7 +145,7 @@ final class CalendarService: Service {
             return events.map { Event($0) }
         }
         Tool(
-            name: "events.create",
+            name: "events_create",
             description: "Create a new calendar event with specified properties",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Contacts.swift
+++ b/App/Services/Contacts.swift
@@ -67,7 +67,7 @@ final class ContactsService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "contacts.me",
+            name: "contacts_me",
             description:
                 "Get contact information about the user, including name, phone number, email, birthday, relations, address, online presence, and occupation. Always run this tool when the user asks a question that requires personal information about themselves.",
             inputSchema: .object(
@@ -85,7 +85,7 @@ final class ContactsService: Service {
         }
 
         Tool(
-            name: "contacts.search",
+            name: "contacts_search",
             description:
                 "Search contacts by name, phone number, and/or email",
             inputSchema: .object(

--- a/App/Services/Location.swift
+++ b/App/Services/Location.swift
@@ -88,7 +88,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
 
     var tools: [Tool] {
         Tool(
-            name: "location.current",
+            name: "location_current",
             description: "Get the user's current location",
             inputSchema: .object(
                 properties: [:],
@@ -171,7 +171,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
         }
 
         Tool(
-            name: "location.geocode",
+            name: "location_geocode",
             description: "Convert an address to geographic coordinates",
             inputSchema: .object(
                 properties: [
@@ -266,7 +266,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
         }
 
         Tool(
-            name: "location.reverse-geocode",
+            name: "location_reverse-geocode",
             description: "Convert geographic coordinates to an address",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Maps.swift
+++ b/App/Services/Maps.swift
@@ -37,7 +37,7 @@ final class MapsService: NSObject, Service {
 
     var tools: [Tool] {
         Tool(
-            name: "maps.search",
+            name: "maps_search",
             description: "Search for places, addresses, points of interest by text query",
             inputSchema: .object(
                 properties: [
@@ -124,7 +124,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "maps.directions",
+            name: "maps_directions",
             description: "Get directions between two locations with optional transport type",
             inputSchema: .object(
                 properties: [
@@ -251,7 +251,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "maps.explore",
+            name: "maps_explore",
             description: "Find points of interest near a location",
             inputSchema: .object(
                 properties: [
@@ -337,7 +337,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "maps.eta",
+            name: "maps_eta",
             description: "Calculate estimated travel time between two locations",
             inputSchema: .object(
                 properties: [
@@ -437,7 +437,7 @@ final class MapsService: NSObject, Service {
         }
 
         Tool(
-            name: "maps.generate",
+            name: "maps_generate",
             description: "Generate a static map image for given coordinates and parameters",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -50,7 +50,7 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
 
     var tools: [Tool] {
         Tool(
-            name: "messages.fetch",
+            name: "messages_fetch",
             description: "Fetch messages from the Messages app",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -22,7 +22,7 @@ final class RemindersService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "reminders.fetch",
+            name: "reminders_fetch",
             description: "Get reminders from the reminders app with flexible filtering options",
             inputSchema: .object(
                 properties: [
@@ -132,7 +132,7 @@ final class RemindersService: Service {
         }
 
         Tool(
-            name: "reminders.create",
+            name: "reminders_create",
             description: "Create a new reminder with specified properties",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Utilities.swift
+++ b/App/Services/Utilities.swift
@@ -28,7 +28,7 @@ final class UtilitiesService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "utilities.beep",
+            name: "utilities_beep",
             description: "Play a system sound",
             inputSchema: .object(
                 properties: [

--- a/App/Services/Weather.swift
+++ b/App/Services/Weather.swift
@@ -13,7 +13,7 @@ final class WeatherService: Service {
 
     var tools: [Tool] {
         Tool(
-            name: "weather.current",
+            name: "weather_current",
             description:
                 "Get current weather for a location",
             inputSchema: .object(
@@ -47,7 +47,7 @@ final class WeatherService: Service {
         }
 
         Tool(
-            name: "weather.daily",
+            name: "weather_daily",
             description: "Get daily weather forecast for a location",
             inputSchema: .object(
                 properties: [
@@ -94,7 +94,7 @@ final class WeatherService: Service {
         }
 
         Tool(
-            name: "weather.hourly",
+            name: "weather_hourly",
             description: "Get hourly weather forecast for a location",
             inputSchema: .object(
                 properties: [
@@ -143,7 +143,7 @@ final class WeatherService: Service {
         }
 
         Tool(
-            name: "weather.minute",
+            name: "weather_minute",
             description: "Get minute-by-minute weather forecast for a location",
             inputSchema: .object(
                 properties: [


### PR DESCRIPTION
Follow-up to #69 

Oops! Turns out that tool names must match `'^[a-zA-Z0-9_-]{1,64}$'` (at least in Claude Desktop). This PR swaps dots for underscores to bring everything back into compliance 🥲 