### PR TITLE
Allow users to automatically connect to trusted clients

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -16,6 +16,11 @@ struct App: SwiftUI.App {
         }
         .menuBarExtraStyle(.window)
         .menuBarExtraAccess(isPresented: $isMenuPresented)
+        
+        Settings {
+            SettingsView(serverController: serverController)
+        }
+        
         .commands {
             CommandGroup(replacing: .appTermination) {
                 Button("Quit") {

--- a/App/Views/ConnectionApprovalView.swift
+++ b/App/Views/ConnectionApprovalView.swift
@@ -69,6 +69,7 @@ struct CheckboxToggleStyle: ToggleStyle {
         HStack {
             Image(systemName: configuration.isOn ? "checkmark.square.fill" : "square")
                 .foregroundColor(configuration.isOn ? .accentColor : .secondary)
+                .accessibilityLabel(configuration.isOn ? "Always trust this client, checked" : "Always trust this client, unchecked")
                 .onTapGesture {
                     configuration.isOn.toggle()
                 }

--- a/App/Views/ConnectionApprovalView.swift
+++ b/App/Views/ConnectionApprovalView.swift
@@ -1,0 +1,168 @@
+import AppKit
+import SwiftUI
+
+struct ConnectionApprovalView: View {
+    let clientName: String
+    let onApprove: (Bool) -> Void  // Bool parameter is for "always trust"
+    let onDeny: () -> Void
+
+    @State private var alwaysTrust = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // Icon
+            Image(.menuIconOn)
+                .resizable()
+                .foregroundColor(.accentColor)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 64, height: 64)
+
+            // Title
+            Text("Client Connection Request")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            // Message
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Allow \"\(clientName)\" to connect to iMCP?")
+
+                Text("This will give the client access to enabled services.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.leading)
+            }
+
+            // Always trust checkbox
+            HStack(alignment: .firstTextBaseline) {
+                Toggle("Always trust this client", isOn: $alwaysTrust)
+                    .toggleStyle(CheckboxToggleStyle())
+                Spacer()
+            }
+            .padding(.bottom, 20)
+
+            // Buttons
+            HStack(spacing: 12) {
+                Button("Deny") {
+                    onDeny()
+                }
+                .buttonStyle(.bordered)
+                .keyboardShortcut(.cancelAction)
+
+                Button("Allow") {
+                    onApprove(alwaysTrust)
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(width: 400, height: 300)
+        .fixedSize()
+        .background(Color(NSColor.windowBackgroundColor))
+        .cornerRadius(12)
+        .shadow(radius: 10)
+    }
+}
+
+struct CheckboxToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            Image(systemName: configuration.isOn ? "checkmark.square.fill" : "square")
+                .foregroundColor(configuration.isOn ? .accentColor : .secondary)
+                .onTapGesture {
+                    configuration.isOn.toggle()
+                }
+
+            configuration.label
+                .onTapGesture {
+                    configuration.isOn.toggle()
+                }
+        }
+    }
+}
+
+@MainActor
+class ConnectionApprovalWindowController: NSObject {
+    private var window: NSWindow?
+    private var approvalView: ConnectionApprovalView?
+
+    func showApprovalWindow(
+        clientName: String,
+        onApprove: @escaping (Bool) -> Void,
+        onDeny: @escaping () -> Void
+    ) {
+        // Create the SwiftUI view
+        let approvalView = ConnectionApprovalView(
+            clientName: clientName,
+            onApprove: { alwaysTrust in
+                onApprove(alwaysTrust)
+                self.closeWindow()
+            },
+            onDeny: {
+                onDeny()
+                self.closeWindow()
+            }
+        )
+
+        // Create the hosting controller
+        let hostingController = NSHostingController(rootView: approvalView)
+
+        // Create the window with fixed size matching the SwiftUI view
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.title = "Connection Request"
+        window.contentViewController = hostingController
+        window.isReleasedWhenClosed = false
+        window.level = .floating
+        window.isMovableByWindowBackground = false
+        window.titlebarAppearsTransparent = false
+
+        // Initial centering
+        window.center()
+
+        // Store references
+        self.window = window
+        self.approvalView = approvalView
+
+        // Activate the app first
+        NSApp.activate(ignoringOtherApps: true)
+
+        // Show the window
+        window.makeKeyAndOrderFront(nil)
+
+        // Center again after showing to ensure proper positioning
+        Task { @MainActor in
+            if let screen = NSScreen.main {
+                let screenRect = screen.visibleFrame
+                let windowRect = window.frame
+                let x = (screenRect.width - windowRect.width) / 2 + screenRect.origin.x
+                let y = (screenRect.height - windowRect.height) / 2 + screenRect.origin.y
+                window.setFrameOrigin(NSPoint(x: x, y: y))
+            }
+        }
+    }
+
+    private func closeWindow() {
+        window?.close()
+        window = nil
+        approvalView = nil
+    }
+}
+
+#Preview {
+    ConnectionApprovalView(
+        clientName: "Claude Desktop",
+        onApprove: { alwaysTrust in
+            print("Approved with always trust: \(alwaysTrust)")
+        },
+        onDeny: {
+            print("Denied")
+        }
+    )
+    .frame(width: 500, height: 400)
+}

--- a/App/Views/ContentView.swift
+++ b/App/Views/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @ObservedObject var serverController: ServerController
     @Binding var isEnabled: Bool
     @Binding var isMenuPresented: Bool
+    @Environment(\.openSettings) private var openSettings
 
     private let aboutWindowController: AboutWindowController
 
@@ -81,6 +82,10 @@ struct ContentView: View {
             }
 
             Divider()
+
+            MenuCommand("Settings...") {
+                openSettings()
+            }
 
             MenuCommand("About iMCP") {
                 aboutWindowController.showWindow(nil)

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var serverController: ServerController
+    @State private var selectedSection: SettingsSection? = .general
+
+    enum SettingsSection: String, CaseIterable, Identifiable {
+        case general = "General"
+
+        var id: String { self.rawValue }
+
+        var icon: String {
+            switch self {
+            case .general: return "gear"
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationView {
+            List(
+                selection: .init(
+                    get: { selectedSection },
+                    set: { section in
+                        selectedSection = section
+                    }
+                )
+            ) {
+                Section {
+                    ForEach(SettingsSection.allCases) { section in
+                        Label(section.rawValue, systemImage: section.icon)
+                            .tag(section)
+                    }
+                }
+            }
+
+            if let selectedSection {
+                switch selectedSection {
+                case .general:
+                    GeneralSettingsView(serverController: serverController)
+                        .navigationTitle("General")
+                        .formStyle(.grouped)
+                }
+            } else {
+                Text("Select a category")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .toolbar {
+            Text("")
+        }
+        .task {
+            let window = NSApplication.shared.keyWindow
+            window?.toolbarStyle = .unified
+            window?.toolbar?.displayMode = .iconOnly
+        }
+        .onAppear {
+            if selectedSection == nil, let firstSection = SettingsSection.allCases.first {
+                selectedSection = firstSection
+            }
+        }
+    }
+
+}
+
+struct GeneralSettingsView: View {
+    @ObservedObject var serverController: ServerController
+    @State private var showingResetAlert = false
+    @State private var selectedClients = Set<String>()
+
+    private var trustedClients: [String] {
+        serverController.getTrustedClients()
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("Trusted Clients")
+                            .font(.headline)
+                        Spacer()
+                        if !trustedClients.isEmpty {
+                            Button("Remove All") {
+                                showingResetAlert = true
+                            }
+                            .buttonStyle(.borderless)
+                            .foregroundStyle(.red)
+                        }
+                    }
+
+                    Text("Clients that automatically connect without approval.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.bottom, 4)
+
+                if trustedClients.isEmpty {
+                    HStack {
+                        Text("No trusted clients")
+                            .foregroundStyle(.secondary)
+                            .italic()
+                        Spacer()
+                    }
+                    .padding(.vertical, 8)
+                } else {
+                    List(trustedClients, id: \.self, selection: $selectedClients) { client in
+                        HStack {
+                            Text(client)
+                                .font(.system(.body, design: .monospaced))
+                            Spacer()
+                        }
+                        .contextMenu {
+                            Button("Remove Client", role: .destructive) {
+                                serverController.removeTrustedClient(client)
+                            }
+                        }
+                    }
+                    .frame(minHeight: 100, maxHeight: 200)
+                    .onDeleteCommand {
+                        for clientID in selectedClients {
+                            serverController.removeTrustedClient(clientID)
+                        }
+                        selectedClients.removeAll()
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .alert("Remove All Trusted Clients", isPresented: $showingResetAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Remove All", role: .destructive) {
+                serverController.resetTrustedClients()
+                selectedClients.removeAll()
+            }
+        } message: {
+            Text(
+                "This will remove all trusted clients. They will need to be approved again when connecting."
+            )
+        }
+    }
+}


### PR DESCRIPTION
Resolves #46 

This PR updates the flow for approving incoming client connections to iMCP. Now, users can check "Always trust this client" to allow clients with that name to connect automatically, without approval in the future. This PR also adds a settings scene that provides controls to manage these trusted clients.

<img width="512" alt="Screenshot 2025-06-21 at 04 45 57" src="https://github.com/user-attachments/assets/b1426529-0868-47fe-ab1f-3f2c91e62e0a" />

<img width="1012" alt="Screenshot 2025-06-21 at 04 46 01" src="https://github.com/user-attachments/assets/0c48a28a-6626-41e5-8d68-d704f68b45ac" />
