### PR TITLE
Fix menu appearance on macOS 26 Tahoe

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -1,3 +1,4 @@
+import MenuBarExtraAccess
 import SwiftUI
 
 @main
@@ -16,11 +17,11 @@ struct App: SwiftUI.App {
         }
         .menuBarExtraStyle(.window)
         .menuBarExtraAccess(isPresented: $isMenuPresented)
-        
+
         Settings {
             SettingsView(serverController: serverController)
         }
-        
+
         .commands {
             CommandGroup(replacing: .appTermination) {
                 Button("Quit") {

--- a/App/Views/ServiceToggleView.swift
+++ b/App/Views/ServiceToggleView.swift
@@ -36,8 +36,7 @@ struct ServiceToggleView: View {
                             .foregroundColor(buttonForegroundColor)
                             .padding(imagePadding)
                     )
-                    .animation(.snappy, value: config.binding.wrappedValue)
-                    .animation(.snappy, value: isEnabled)
+                    .animation(.snappy, value: config.binding.wrappedValue || isEnabled)
             }
             .buttonStyle(PlainButtonStyle())
             .disabled(!isEnabled)

--- a/App/Views/ServiceToggleView.swift
+++ b/App/Views/ServiceToggleView.swift
@@ -1,20 +1,23 @@
-import MacControlCenterUI
 import SwiftUI
+import AppKit
 
 struct ServiceToggleView: View {
     let config: ServiceConfig
     @State private var isServiceActivated = false
+    
+    // MARK: Environment
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.isEnabled) private var isEnabled
+    
+    // MARK: Private State
+    private let buttonSize: CGFloat = 26
+    private let imagePadding: CGFloat = 5
 
     var body: some View {
-        MenuCircleToggle(
-            config.name,
-            isOn: config.binding,
-            style: .init(
-                image: Image(systemName: config.iconName),
-                color: config.color
-            ),
-            onClick: { enabled in
-                if enabled && !isServiceActivated {
+        HStack {
+            Button(action: {
+                config.binding.wrappedValue.toggle()
+                if config.binding.wrappedValue && !isServiceActivated {
                     Task {
                         do {
                             try await config.service.activate()
@@ -23,10 +26,48 @@ struct ServiceToggleView: View {
                         }
                     }
                 }
+            }) {
+                Circle()
+                    .fill(buttonBackgroundColor)
+                    .overlay(
+                        Image(systemName: config.iconName)
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundColor(buttonForegroundColor)
+                            .padding(imagePadding)
+                    )
+                    .animation(.snappy, value: config.binding.wrappedValue)
+                    .animation(.snappy, value: isEnabled)
             }
-        )
+            .buttonStyle(PlainButtonStyle())
+            .disabled(!isEnabled)
+            .frame(width: buttonSize, height: buttonSize)
+            
+            Text(config.name)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundColor(isEnabled ? Color.primary : .primary.opacity(0.5))
+        }
+        .frame(height: buttonSize)
+        .padding(.horizontal, 14)
         .task {
             isServiceActivated = await config.isActivated
+        }
+    }
+    
+    private var buttonBackgroundColor: Color {
+        if config.binding.wrappedValue {
+            return config.color.opacity(isEnabled ? 1.0 : 0.4)
+        } else {
+            return Color(NSColor.controlColor)
+                .opacity(isEnabled ? (colorScheme == .dark ? 0.8 : 0.2) : 0.1)
+        }
+    }
+
+    private var buttonForegroundColor: Color {
+        if config.binding.wrappedValue {
+            return .white.opacity(isEnabled ? 1.0 : 0.6)
+        } else {
+            return .primary.opacity(isEnabled ? 0.7 : 0.4)
         }
     }
 }

--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		F825BDBF2D9AD00E0063ADD7 /* ServiceLifecycle in Frameworks */ = {isa = PBXBuildFile; productRef = F825BDBE2D9AD00E0063ADD7 /* ServiceLifecycle */; };
 		F825BDC12D9AD00E0063ADD7 /* UnixSignals in Frameworks */ = {isa = PBXBuildFile; productRef = F825BDC02D9AD00E0063ADD7 /* UnixSignals */; };
 		F873F48D2D712BCF0035CD0A /* Ontology in Frameworks */ = {isa = PBXBuildFile; productRef = F873F48C2D712BCF0035CD0A /* Ontology */; };
+		F87796FC2E0764AE00328CC6 /* MenuBarExtraAccess in Frameworks */ = {isa = PBXBuildFile; productRef = F87796FB2E0764AE00328CC6 /* MenuBarExtraAccess */; };
 		F88358372D64A085000317CD /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = F88358362D64A085000317CD /* Logging */; };
 		F885C6B82D66079100963B25 /* imcp-server in Copy Executables */ = {isa = PBXBuildFile; fileRef = F8F44EB62D5908D00075D79C /* imcp-server */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F8A7DE3E2DCB76F700530587 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8A7DE3D2DCB76F700530587 /* MCP */; };
@@ -20,7 +21,6 @@
 		F8D7C31A2DCBD32100A4775F /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8D7C3192DCBD32100A4775F /* MCP */; };
 		F8D8C48E2DCE0E6800369E5C /* JSONSchema in Frameworks */ = {isa = PBXBuildFile; productRef = F8D8C48D2DCE0E6800369E5C /* JSONSchema */; };
 		F8F1D2F82D6F9E0C00F6323D /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8F44E9C2D5903F70075D79C /* MCP */; };
-		F8F1D33F2D6FA7EB00F6323D /* MacControlCenterUI in Frameworks */ = {isa = PBXBuildFile; productRef = F8F1D33E2D6FA7EB00F6323D /* MacControlCenterUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -83,8 +83,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				F809556E2D7888920055B911 /* TypedStream in Frameworks */,
+				F87796FC2E0764AE00328CC6 /* MenuBarExtraAccess in Frameworks */,
 				F873F48D2D712BCF0035CD0A /* Ontology in Frameworks */,
-				F8F1D33F2D6FA7EB00F6323D /* MacControlCenterUI in Frameworks */,
 				F8D7C31A2DCBD32100A4775F /* MCP in Frameworks */,
 				F8A7DE3E2DCB76F700530587 /* MCP in Frameworks */,
 				F8F1D2F82D6F9E0C00F6323D /* MCP in Frameworks */,
@@ -148,7 +148,6 @@
 			name = iMCP;
 			packageProductDependencies = (
 				F8F44E9C2D5903F70075D79C /* MCP */,
-				F8F1D33E2D6FA7EB00F6323D /* MacControlCenterUI */,
 				F873F48C2D712BCF0035CD0A /* Ontology */,
 				F809556D2D7888920055B911 /* TypedStream */,
 				F809556F2D7888920055B911 /* iMessage */,
@@ -156,6 +155,7 @@
 				F8D7C3162DCBD30500A4775F /* MCP */,
 				F8D7C3192DCBD32100A4775F /* MCP */,
 				F8D8C48D2DCE0E6800369E5C /* JSONSchema */,
+				F87796FB2E0764AE00328CC6 /* MenuBarExtraAccess */,
 			);
 			productName = iMCP;
 			productReference = F8F44E6D2D59038D0075D79C /* iMCP.app */;
@@ -216,12 +216,12 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				F88358352D64A085000317CD /* XCRemoteSwiftPackageReference "swift-log" */,
-				F8F1D33D2D6FA7EB00F6323D /* XCRemoteSwiftPackageReference "MacControlCenterUI" */,
 				F873F48B2D712BCF0035CD0A /* XCRemoteSwiftPackageReference "Ontology" */,
 				F809556C2D7888920055B911 /* XCRemoteSwiftPackageReference "madrid" */,
 				F825BDBD2D9AD00E0063ADD7 /* XCRemoteSwiftPackageReference "swift-service-lifecycle" */,
 				F8D7C3182DCBD32100A4775F /* XCRemoteSwiftPackageReference "swift-sdk" */,
 				F8D8C48C2DCE0E6800369E5C /* XCRemoteSwiftPackageReference "JSONSchema" */,
+				F87796FA2E0764AE00328CC6 /* XCRemoteSwiftPackageReference "MenuBarExtraAccess" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = F8F44E6E2D59038D0075D79C /* Products */;
@@ -562,6 +562,14 @@
 				minimumVersion = 0.6.0;
 			};
 		};
+		F87796FA2E0764AE00328CC6 /* XCRemoteSwiftPackageReference "MenuBarExtraAccess" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/orchetect/MenuBarExtraAccess";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.1;
+			};
+		};
 		F88358352D64A085000317CD /* XCRemoteSwiftPackageReference "swift-log" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-log";
@@ -584,14 +592,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.1.0;
-			};
-		};
-		F8F1D33D2D6FA7EB00F6323D /* XCRemoteSwiftPackageReference "MacControlCenterUI" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/orchetect/MacControlCenterUI";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -622,6 +622,11 @@
 			package = F873F48B2D712BCF0035CD0A /* XCRemoteSwiftPackageReference "Ontology" */;
 			productName = Ontology;
 		};
+		F87796FB2E0764AE00328CC6 /* MenuBarExtraAccess */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F87796FA2E0764AE00328CC6 /* XCRemoteSwiftPackageReference "MenuBarExtraAccess" */;
+			productName = MenuBarExtraAccess;
+		};
 		F88358362D64A085000317CD /* Logging */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F88358352D64A085000317CD /* XCRemoteSwiftPackageReference "swift-log" */;
@@ -648,11 +653,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8D8C48C2DCE0E6800369E5C /* XCRemoteSwiftPackageReference "JSONSchema" */;
 			productName = JSONSchema;
-		};
-		F8F1D33E2D6FA7EB00F6323D /* MacControlCenterUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F8F1D33D2D6FA7EB00F6323D /* XCRemoteSwiftPackageReference "MacControlCenterUI" */;
-			productName = MacControlCenterUI;
 		};
 		F8F44E9C2D5903F70075D79C /* MCP */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "004283a7666aa08b9e26e1502244d4daebd17a348056bb49cab730594e6e1f85",
+  "originHash" : "407f2cefef44025b011008383143afe9b4a2f6d4725738f7f0f2a7386d66d1cb",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "1c3b710fb8e65e6a651abda0b32195ff6750d84b",
         "version" : "1.1.0"
-      }
-    },
-    {
-      "identity" : "maccontrolcenterui",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/orchetect/MacControlCenterUI",
-      "state" : {
-        "revision" : "ee2003b6508de0997cbe6ebb238801f297a450ab",
-        "version" : "2.4.1"
       }
     },
     {


### PR DESCRIPTION
Currently, building iMCP with the latest Xcode 26 beta (17A5241e) results in weird visual bugs when hovering over "Configure Claude Desktop" and other commands. 

<img width="344" alt="Screenshot 2025-06-21 at 16 31 12" src="https://github.com/user-attachments/assets/928e6931-2202-458c-9c6f-a4b3f4364ed7" />

(Curiously, the latest release of iMCP, built with GA Xcode, _doesn't_ have this problem...)   

This PR fixes those regressions. In the process, it replaces MacControlCenterUI with custom UI and [MenuBarExtraAccess](https://github.com/orchetect/MenuBarExtraAccess) package. It also fixes a runtime warning originating from that library:

> NSVisualEffectView subclass says YES to allowsVibrancy. NSVisualEffectView does not support being vibrantly blended *itself*. This may break in the future.

Unfortunately, the current macOS 26.0 Beta (25A5279m) seems to have broken the introspection hooks used by MenuBarExtraAccess that let us programmatically dismiss the menu when clicking items.