### PR TITLE
Fix excessive heartbeat logging in CLI

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -8,7 +8,7 @@ import struct Foundation.Data
 import class Foundation.RunLoop
 
 var log = Logger(label: "me.mattt.iMCP.server") { StreamLogHandler.standardError(label: $0) }
-log.logLevel = .debug
+log.logLevel = .info
 
 // Network setup
 let serviceType = "_mcp._tcp"


### PR DESCRIPTION
## Description

Resolves #105

This PR fixes the excessive heartbeat logging issue with a minimal, single-line change.

## The Problem

The CLI was logging verbose debug messages for every heartbeat message (which occur every few seconds), making the logs difficult to read and flooding stderr with noise.

## The Solution

Change the default log level from `.debug` to `.info` (line 11 in `CLI/main.swift`).

This simple change:
- ✅ Eliminates all debug-level logs, including the verbose heartbeat messages
- ✅ Preserves debug logs in code for developers who need them
- ✅ Still logs important events (info, warning, and error levels)
- ✅ Non-invasive, minimal change (1 line)

## Why This Approach?

1. **Keeps it simple** - No code deletion, just a log level change
2. **Developer-friendly** - Debug logs remain available by manually changing to `.debug`
3. **Maintainable** - Future debug logs will automatically respect the log level
4. **Safe** - Doesn't remove any functionality, just changes visibility

## Testing

The change maintains all existing functionality:
- Heartbeats are still detected and filtered correctly
- Service discovery, connection state changes, and errors are still logged
- For verbose debugging, developers can change `log.logLevel = .info` to `.debug`

## Before/After

**Before (with .debug):**
```
[DEBUG] Heartbeat signature detected in received network data using MCP definition.
[DEBUG] Full MCP heartbeat message (12 bytes) received from network, skipping output.
[DEBUG] Heartbeat signature detected in received network data using MCP definition.
[DEBUG] Full MCP heartbeat message (12 bytes) received from network, skipping output.
... (every few seconds)
```

**After (with .info):**
```
[INFO] Starting Bonjour service discovery...
[INFO] Selected endpoint: ...
... (clean, useful logs only)
```