### PR TITLE
Bump Ontology package dependency to 0.8.0

### DIFF
--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 			repositoryURL = "https://github.com/loopwork-ai/Ontology";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.0;
+				minimumVersion = 0.8.0;
 			};
 		};
 		F87796FA2E0764AE00328CC6 /* XCRemoteSwiftPackageReference "MenuBarExtraAccess" */ = {

--- a/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/loopwork-ai/Ontology",
       "state" : {
-        "revision" : "27969c8ddedff24f90f366fcb1f79aa9ed92e8c5",
-        "version" : "0.7.1"
+        "revision" : "3d1d2545b826909a3f6499f2ef661429bf9c10d5",
+        "version" : "0.8.0"
       }
     },
     {


### PR DESCRIPTION
Related to https://github.com/mattt/Ontology/pull/15

With this update, reminders now include the name of the list to which they belong.