### PR TITLE
Fix NetworkTransport continuation crash by bumping swift-sdk

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -432,6 +432,8 @@ actor MCPConnectionManager {
         self.transport = NetworkTransport(
             connection: connection,
             logger: nil,
+            heartbeatConfig: .disabled,
+            reconnectionConfig: .disabled,
             bufferConfig: .unlimited
         )
 
@@ -873,7 +875,10 @@ actor ServerNetworkManager {
                                 .init(
                                     name: tool.name,
                                     description: tool.description,
-                                    inputSchema: tool.inputSchema,
+                                    inputSchema: {
+                                        let data = try! JSONEncoder().encode(tool.inputSchema)
+                                        return try! JSONDecoder().decode(Value.self, from: data)
+                                    }(),
                                     annotations: tool.annotations
                                 )
                             )
@@ -889,7 +894,7 @@ actor ServerNetworkManager {
         await server.withMethodHandler(CallTool.self) { [weak self] params in
             guard let self = self else {
                 return CallTool.Result(
-                    content: [.text("Server unavailable")],
+                    content: [.text(text: "Server unavailable", annotations: nil, _meta: nil)],
                     isError: true
                 )
             }
@@ -899,7 +904,13 @@ actor ServerNetworkManager {
             guard await self.isEnabledState else {
                 log.notice("Tool call rejected: iMCP is disabled")
                 return CallTool.Result(
-                    content: [.text("iMCP is currently disabled. Please enable it to use tools.")],
+                    content: [
+                        .text(
+                            text: "iMCP is currently disabled. Please enable it to use tools.",
+                            annotations: nil,
+                            _meta: nil
+                        )
+                    ],
                     isError: true
                 )
             }
@@ -928,7 +939,9 @@ actor ServerNetworkManager {
                                 content: [
                                     .audio(
                                         data: data.base64EncodedString(),
-                                        mimeType: mimeType
+                                        mimeType: mimeType,
+                                        annotations: nil,
+                                        _meta: nil
                                     )
                                 ],
                                 isError: false
@@ -939,7 +952,8 @@ actor ServerNetworkManager {
                                     .image(
                                         data: data.base64EncodedString(),
                                         mimeType: mimeType,
-                                        metadata: nil
+                                        annotations: nil,
+                                        _meta: nil
                                     )
                                 ],
                                 isError: false
@@ -953,20 +967,32 @@ actor ServerNetworkManager {
                             let data = try encoder.encode(value)
                             let text = String(data: data, encoding: .utf8)!
 
-                            return CallTool.Result(content: [.text(text)], isError: false)
+                            return CallTool.Result(
+                                content: [.text(text: text, annotations: nil, _meta: nil)],
+                                isError: false
+                            )
                         }
                     } catch {
                         log.error(
                             "Error executing tool \(params.name): \(error.localizedDescription)"
                         )
-                        return CallTool.Result(content: [.text("Error: \(error)")], isError: true)
+                        return CallTool.Result(
+                            content: [.text(text: "Error: \(error)", annotations: nil, _meta: nil)],
+                            isError: true
+                        )
                     }
                 }
             }
 
             log.error("Tool not found or service not enabled: \(params.name)")
             return CallTool.Result(
-                content: [.text("Tool not found or service not enabled: \(params.name)")],
+                content: [
+                    .text(
+                        text: "Tool not found or service not enabled: \(params.name)",
+                        annotations: nil,
+                        _meta: nil
+                    )
+                ],
                 isError: true
             )
         }

--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -632,7 +632,7 @@
 			repositoryURL = "https://github.com/modelcontextprotocol/swift-sdk";
 			requirement = {
 				kind = revision;
-				revision = 106167bad12cd8d004b0cbfcec8211c5408794d8;
+				revision = 973b46b8f761eba626dfbc399693871128ec60f1;
 			};
 		};
 		F8D8C48C2DCE0E6800369E5C /* XCRemoteSwiftPackageReference "JSONSchema" */ = {

--- a/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -4,7 +4,7 @@
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/loopwork-ai/eventsource.git",
+      "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
         "revision" : "07957602bb99a5355c810187e66e6ce378a1057d",
         "version" : "1.1.1"
@@ -56,6 +56,15 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -74,11 +83,20 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
+        "version" : "2.95.0"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk",
       "state" : {
-        "revision" : "106167bad12cd8d004b0cbfcec8211c5408794d8"
+        "revision" : "973b46b8f761eba626dfbc399693871128ec60f1"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Bumps `modelcontextprotocol/swift-sdk` from `106167b` to `973b46b` (V0.11.x), which rewrites `NetworkTransport.connect()` to use `AsyncStream` instead of `withCheckedThrowingContinuation` with a resettable boolean guard
- Updates `ServerController.swift` for the new `Tool.Content` API (label changes to `text`/`image`/`audio` enum cases, `inputSchema` type change from `JSONSchema` to `Value`)
- Disables reconnection and heartbeats in `MCPConnectionManager` since iMCP accepts fresh per-client connections

## Problem

The pinned swift-sdk revision had a bug where `connectionContinuationResumed` (an instance-level boolean) was reset to `false` on each `connect()` call. If NWConnection state transitions fired concurrently, old Tasks from previous state handlers could double-resume stale continuations, causing `SWIFT TASK CONTINUATION MISUSE` crashes. This made iMCP crash immediately on client connection (macOS Sequoia 15.7.3 and Tahoe).

Relates to #136.

## Test plan

- [x] Builds successfully with `xcodebuild -scheme iMCP -configuration Debug build`
- [x] Passes `swift format lint --strict --recursive .`
- [x] App launches and stays alive in the menu bar (no continuation crash)
- [x] MCP server accepts client connections via stdio transport
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)