### PR TITLE
Fix Claude Desktop config overwrite when using save panel

### DIFF
--- a/App/Integrations/ClaudeDesktop.swift
+++ b/App/Integrations/ClaudeDesktop.swift
@@ -259,10 +259,26 @@ private func updateConfig(
         throw ClaudeDesktop.Error.noLocationSelected
     }
 
-    // Create the file first
+    // The save panel grants us access to the selected URL, so re-read any
+    // existing contents to merge rather than overwrite.
     log.debug("Creating configuration at selected URL: \(selectedURL.path)")
     do {
-        try writeConfig(updatedConfig, to: selectedURL)
+        var configToWrite = updatedConfig
+        if FileManager.default.fileExists(atPath: selectedURL.path) {
+            log.debug("Selected file exists, re-reading to merge existing config")
+            let existingData = try Data(contentsOf: selectedURL)
+            let existingConfig = try jsonDecoder.decode([String: Value].self, from: existingData)
+            // Start from the existing config and upsert iMCP into it
+            configToWrite = existingConfig
+            if var mcpServers = existingConfig["mcpServers"]?.objectValue {
+                mcpServers["iMCP"] = imcpServerValue
+                configToWrite["mcpServers"] = .object(mcpServers)
+            } else {
+                configToWrite["mcpServers"] = .object(["iMCP": imcpServerValue])
+            }
+        }
+
+        try writeConfig(configToWrite, to: selectedURL)
 
         // Then create the security-scoped bookmark
         log.debug("Creating security-scoped access for selected URL")


### PR DESCRIPTION
## Summary
- When the save panel fallback is used (first run, no security-scoped bookmark), the existing config file contents were lost because `loadConfig()` couldn't read the file due to sandbox restrictions
- The save panel grants file access, so now re-reads and merges the existing config before writing instead of overwriting with the empty default
- Preserves all existing `preferences`, other `mcpServers` entries, and any other top-level keys

## Test plan
- [ ] Delete any stored security-scoped bookmark (fresh install scenario)
- [ ] Add custom entries to `claude_desktop_config.json` (e.g. `preferences`, other MCP servers)
- [ ] Click "Configure Claude Desktop" — verify the save panel appears
- [ ] Select the existing config file — verify existing entries are preserved and iMCP is added/updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)