### PR TITLE
Fix fatal crash when Bonjour connection drops mid-session

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -475,7 +475,7 @@ actor MCPService: Service {
     private var currentProxy: StdioProxy?
 
     func run() async throws {
-        while true {
+        while !Task.isShuttingDownGracefully {
             do {
                 await log.info("Starting Bonjour service discovery...")
 
@@ -617,19 +617,22 @@ actor MCPService: Service {
             }
         }
     }
-
-    func shutdown() async throws {
-        browser?.cancel()
-        if let proxy = currentProxy {
-            await proxy.stop()
-        }
-    }
 }
 
-// Update the ServiceLifecycle initialization
+// `.gracefullyShutdownGroup` is load-bearing: `MCPService.run()` returns
+// when the Bonjour connection to the menubar app drops. With the library
+// default of `.cancelGroup`, that return raises `ServiceGroupError` at the
+// top level → Swift runtime fatal error. See ServiceGroupConfigurationTests.
 let lifecycle = ServiceGroup(
     configuration: .init(
-        services: [MCPService()],
+        services: [
+            .init(
+                service: MCPService(),
+                successTerminationBehavior: .gracefullyShutdownGroup,
+                failureTerminationBehavior: .gracefullyShutdownGroup
+            )
+        ],
+        gracefulShutdownSignals: [.sigint, .sigterm],
         logger: log
     )
 )

--- a/CLITests/ServiceGroupConfigurationTests.swift
+++ b/CLITests/ServiceGroupConfigurationTests.swift
@@ -1,0 +1,76 @@
+import Logging
+import ServiceLifecycle
+import ServiceLifecycleTestKit
+import XCTest
+
+/// Regression tests for the `ServiceGroup` configuration used by `imcp-server`.
+///
+/// These tests guard against the fatal crash first diagnosed on 2026-04-23:
+/// if `successTerminationBehavior` is left at its default of `.cancelGroup`, a
+/// `Service.run()` that returns normally (as `MCPService.run()` does when the
+/// Bonjour connection drops) causes `ServiceGroup` to throw
+/// `ServiceGroupError.serviceFinishedUnexpectedly`, which becomes a Swift
+/// top-level fatal error. See `CLI/main.swift` for the production configuration
+/// this file mirrors.
+final class ServiceGroupConfigurationTests: XCTestCase {
+
+    /// When a service returns normally from `run()`, the `ServiceGroup` must
+    /// exit cleanly rather than throwing. This is the primary regression the
+    /// production fix addresses.
+    func testServiceReturningNormallyExitsGroupCleanly() async throws {
+        struct ImmediatelyReturningService: Service {
+            func run() async throws {}
+        }
+
+        let group = ServiceGroup(
+            configuration: .init(
+                services: [
+                    .init(
+                        service: ImmediatelyReturningService(),
+                        successTerminationBehavior: .gracefullyShutdownGroup,
+                        failureTerminationBehavior: .gracefullyShutdownGroup
+                    )
+                ],
+                logger: Logger(label: "test")
+            )
+        )
+
+        try await group.run()
+    }
+
+    /// Demonstrates the pre-fix behavior: with the library default of
+    /// `.cancelGroup`, a service returning from `run()` causes `ServiceGroup.run()`
+    /// to throw. If this ever stops throwing — e.g. the library changes its
+    /// default — the production fix may no longer be necessary.
+    func testDefaultCancelGroupThrowsWhenServiceReturns() async {
+        struct ImmediatelyReturningService: Service {
+            func run() async throws {}
+        }
+
+        let group = ServiceGroup(
+            configuration: .init(
+                services: [ImmediatelyReturningService()],
+                logger: Logger(label: "test")
+            )
+        )
+
+        do {
+            try await group.run()
+            XCTFail("Expected ServiceGroup.run() to throw with default .cancelGroup behavior")
+        } catch {
+            // Expected — this is the original failure mode that the production
+            // config avoids by using .gracefullyShutdownGroup.
+        }
+    }
+
+    /// The reconnect loop in `MCPService.run()` uses
+    /// `while !Task.isShuttingDownGracefully` to exit promptly when the group
+    /// is shutting down. Verify the task-local mechanism works as expected.
+    func testTaskIsShuttingDownGracefullyObservedAfterTrigger() async throws {
+        await testGracefulShutdown { trigger in
+            XCTAssertFalse(Task.isShuttingDownGracefully)
+            trigger.triggerGracefulShutdown()
+            XCTAssertTrue(Task.isShuttingDownGracefully)
+        }
+    }
+}

--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		76F80A6E3EDBFB02048A6ED8 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0E66768348853754D32208C /* Cocoa.framework */; };
+		826C0834A5B647F8A918E54D /* ServiceLifecycle in Frameworks */ = {isa = PBXBuildFile; productRef = DCE061F8A68D0CD546D919E2 /* ServiceLifecycle */; };
+		8DFCE9E4CBCBEB93A32E8560 /* ServiceLifecycleTestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1CD6B9E157EEC273F178543D /* ServiceLifecycleTestKit */; };
+		930214FCD680D7D74158F215 /* ServiceGroupConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E148EAC5AC8B3263C5AA13 /* ServiceGroupConfigurationTests.swift */; };
 		F809556E2D7888920055B911 /* TypedStream in Frameworks */ = {isa = PBXBuildFile; productRef = F809556D2D7888920055B911 /* TypedStream */; };
 		F80955702D7888920055B911 /* iMessage in Frameworks */ = {isa = PBXBuildFile; productRef = F809556F2D7888920055B911 /* iMessage */; };
 		F825BDBF2D9AD00E0063ADD7 /* ServiceLifecycle in Frameworks */ = {isa = PBXBuildFile; productRef = F825BDBE2D9AD00E0063ADD7 /* ServiceLifecycle */; };
@@ -21,6 +25,7 @@
 		F8D7C31A2DCBD32100A4775F /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8D7C3192DCBD32100A4775F /* MCP */; };
 		F8D8C48E2DCE0E6800369E5C /* JSONSchema in Frameworks */ = {isa = PBXBuildFile; productRef = F8D8C48D2DCE0E6800369E5C /* JSONSchema */; };
 		F8F1D2F82D6F9E0C00F6323D /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8F44E9C2D5903F70075D79C /* MCP */; };
+		F9E9902DC72D90F6C423EFE2 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 48ABEE9E6903427DD79096A1 /* Logging */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +52,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6A5CFBBEC66BC8CDA9D65496 /* imcp-serverTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "imcp-serverTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		75E148EAC5AC8B3263C5AA13 /* ServiceGroupConfigurationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ServiceGroupConfigurationTests.swift; sourceTree = "<group>"; };
+		E0E66768348853754D32208C /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		F8F44E6D2D59038D0075D79C /* iMCP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iMCP.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8F44EB62D5908D00075D79C /* imcp-server */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "imcp-server"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -72,12 +80,25 @@
 		};
 		F8F44EB72D5908D00075D79C /* CLI */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = CLI;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		244B6A9EEE0501F04569493A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				76F80A6E3EDBFB02048A6ED8 /* Cocoa.framework in Frameworks */,
+				826C0834A5B647F8A918E54D /* ServiceLifecycle in Frameworks */,
+				8DFCE9E4CBCBEB93A32E8560 /* ServiceLifecycleTestKit in Frameworks */,
+				F9E9902DC72D90F6C423EFE2 /* Logging in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8F44E6A2D59038D0075D79C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -108,12 +129,39 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		13058B0C8A894B6DB0A7D2A8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F53ADAE0D917F06C8D01D825 /* OS X */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9784E568F0621136136A0EAC /* CLITests */ = {
+			isa = PBXGroup;
+			children = (
+				75E148EAC5AC8B3263C5AA13 /* ServiceGroupConfigurationTests.swift */,
+			);
+			name = CLITests;
+			path = CLITests;
+			sourceTree = "<group>";
+		};
+		F53ADAE0D917F06C8D01D825 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				E0E66768348853754D32208C /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
 		F8F44E642D59038D0075D79C = {
 			isa = PBXGroup;
 			children = (
 				F8F44E6F2D59038D0075D79C /* App */,
 				F8F44EB72D5908D00075D79C /* CLI */,
 				F8F44E6E2D59038D0075D79C /* Products */,
+				13058B0C8A894B6DB0A7D2A8 /* Frameworks */,
+				9784E568F0621136136A0EAC /* CLITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -122,6 +170,7 @@
 			children = (
 				F8F44E6D2D59038D0075D79C /* iMCP.app */,
 				F8F44EB62D5908D00075D79C /* imcp-server */,
+				6A5CFBBEC66BC8CDA9D65496 /* imcp-serverTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -129,6 +178,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		8F6A71ADC0CC6BD168A9167D /* imcp-serverTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 420FB1A6748E0C4FEF3CC576 /* Build configuration list for PBXNativeTarget "imcp-serverTests" */;
+			buildPhases = (
+				B53F67B71CE8E2EB7B5CB823 /* Sources */,
+				244B6A9EEE0501F04569493A /* Frameworks */,
+				9C8F6A2CF5080CD1E01C127F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "imcp-serverTests";
+			packageProductDependencies = (
+				DCE061F8A68D0CD546D919E2 /* ServiceLifecycle */,
+				1CD6B9E157EEC273F178543D /* ServiceLifecycleTestKit */,
+				48ABEE9E6903427DD79096A1 /* Logging */,
+			);
+			productName = "imcp-serverTests";
+			productReference = 6A5CFBBEC66BC8CDA9D65496 /* imcp-serverTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		F8F44E6C2D59038D0075D79C /* iMCP */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F8F44E922D59038E0075D79C /* Build configuration list for PBXNativeTarget "iMCP" */;
@@ -230,11 +301,19 @@
 			targets = (
 				F8F44E6C2D59038D0075D79C /* iMCP */,
 				F8F44EB52D5908D00075D79C /* imcp-server */,
+				8F6A71ADC0CC6BD168A9167D /* imcp-serverTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		9C8F6A2CF5080CD1E01C127F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8F44E6B2D59038D0075D79C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -245,6 +324,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		B53F67B71CE8E2EB7B5CB823 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				930214FCD680D7D74158F215 /* ServiceGroupConfigurationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8F44E692D59038D0075D79C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -262,6 +349,38 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		730CCB1C20FB35151860DD40 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundlePackageType = BNDL;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.mattt.iMCP.imcp-serverTests";
+				PRODUCT_MODULE_NAME = imcp_serverTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		8E4FC3A465C4E80757FEFE6B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundlePackageType = BNDL;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.mattt.iMCP.imcp-serverTests";
+				PRODUCT_MODULE_NAME = imcp_serverTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
 		F8F44E902D59038E0075D79C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -557,6 +676,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		420FB1A6748E0C4FEF3CC576 /* Build configuration list for PBXNativeTarget "imcp-serverTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				730CCB1C20FB35151860DD40 /* Release */,
+				8E4FC3A465C4E80757FEFE6B /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F8F44E682D59038D0075D79C /* Build configuration list for PBXProject "iMCP" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -646,6 +774,21 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		1CD6B9E157EEC273F178543D /* ServiceLifecycleTestKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F825BDBD2D9AD00E0063ADD7 /* XCRemoteSwiftPackageReference "swift-service-lifecycle" */;
+			productName = ServiceLifecycleTestKit;
+		};
+		48ABEE9E6903427DD79096A1 /* Logging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F88358352D64A085000317CD /* XCRemoteSwiftPackageReference "swift-log" */;
+			productName = Logging;
+		};
+		DCE061F8A68D0CD546D919E2 /* ServiceLifecycle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F825BDBD2D9AD00E0063ADD7 /* XCRemoteSwiftPackageReference "swift-service-lifecycle" */;
+			productName = ServiceLifecycle;
+		};
 		F809556D2D7888920055B911 /* TypedStream */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F809556C2D7888920055B911 /* XCRemoteSwiftPackageReference "madrid" */;

--- a/iMCP.xcodeproj/xcshareddata/xcschemes/imcp-serverTests.xcscheme
+++ b/iMCP.xcodeproj/xcshareddata/xcschemes/imcp-serverTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8F6A71ADC0CC6BD168A9167D"
+               BuildableName = "imcp-serverTests.xctest"
+               BlueprintName = "imcp-serverTests"
+               ReferencedContainer = "container:iMCP.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary

`imcp-server` crashes with a Swift top-level fatal error whenever the Bonjour link to the menubar app drops mid-session. Observed 15 times in one week of Claude Desktop MCP logs on a single machine. Every recurrence produces:

```
critical: Connection closed, terminating...
debug: [ServiceLifecycle] Service finished unexpectedly. Cancelling group.
Swift/ErrorType.swift:254: Fatal error: Error raised at top level:
  ServiceGroupError: errorCode: A service has finished unexpectedly.
```

The process dies with SIGTRAP-style termination instead of exiting cleanly, which:
- Defeats Claude Desktop's supervisor-driven restart.
- Leaves zombie `imcp-server` processes accumulating (related to #28).
- Amplifies the impact of any menubar-side connection close — including the Bonjour leaks described in #165 and the vague "frequent crashing" in #163.

## Root cause

`MCPService.run()` handles `StdioProxyError.connectionClosed` and `NWError` codes 54/57 by `return`-ing. In `swift-service-lifecycle` 2.x, the default `ServiceConfiguration.successTerminationBehavior` is `.cancelGroup` — meaning a `Service.run()` that returns normally is treated as "finished unexpectedly" and the group raises `ServiceGroupError`. `gracefulShutdownSignals: []` (the default) also means SIGINT/SIGTERM are silently ignored today.

## Fix

- `successTerminationBehavior: .gracefullyShutdownGroup` — `return`ing from `run()` shuts the group down cleanly; `lifecycle.run()` completes without throwing; process exits with status 0.
- `failureTerminationBehavior: .gracefullyShutdownGroup` — same for thrown errors, since there's nothing another layer can recover.
- `gracefulShutdownSignals: [.sigint, .sigterm]` — signals now trigger graceful shutdown.
- `while !Task.isShuttingDownGracefully` at the top of the reconnect loop — shutdown is observable between iterations so signals don't wait on the 5s retry sleep.
- Remove the dead `MCPService.shutdown()` method. The `Service` protocol in swift-service-lifecycle 2.x declares only `run()`, so that method was never called.

## Test plan

New `imcp-serverTests` XCTest target with three regression tests:

- `testServiceReturningNormallyExitsGroupCleanly` — the primary regression guard.
- `testDefaultCancelGroupThrowsWhenServiceReturns` — pins the pre-fix failure mode so the library's default behavior changing is detectable.
- `testTaskIsShuttingDownGracefullyObservedAfterTrigger` — validates the loop's shutdown observation via `ServiceLifecycleTestKit`.

Run: `xcodebuild -project iMCP.xcodeproj -scheme imcp-serverTests test` — 3/3 pass.

Manual verification:
- [x] SIGTERM → exit code 0, `[ServiceLifecycle] Signal caught. Shutting down the group.`
- [x] Bonjour peer disappears → exit code 0, log line changed from `Service finished unexpectedly. Cancelling group.` to `Service finished. Gracefully shutting down group.`
- [x] Full `initialize` → `tools/list` → stdin close round-trip exits cleanly.
- [x] No orphan `imcp-server` processes after repeated spawns.

## Related

- Likely fixes #163 (frequent crashing — no stack trace in the report but the fatal-error signature matches what supervisors would see).
- Makes #165 less user-visible: the menubar-side `NWConnection` leak still happens, but the CLI no longer fatal-errors when the peer goes unhealthy.
- Likely resolves #28: zombie `imcp-server` processes after Claude Desktop termination. Those accumulate because the process exits via fatal error rather than cleanly. A process-table check after applying this change shows zero orphans.

## Scope / non-goals

Deliberately out of scope — each is a candidate follow-up:
- The non-cancellable 30s Bonjour discovery (`withCheckedThrowingContinuation` in `MCPService.run()`). Worst-case signal-to-exit time when stuck in that state remains ~30s. Relevant to #24.
- Why the menubar app drops the Bonjour connection after `notifications/tools/list_changed` in some logs. Menubar-side; unrelated to this CLI fix.
- Pre-existing per-iteration browser/proxy cleanup leaks in `MCPService.run()`.

Independent of #162 (SDK 0.12.0 bump); either can merge first.