### PR TITLE
Expose full JSON schema with union types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ playground.xcworkspace
 # .swiftpm
 
 .build/
+build/
 
 # Release artifacts
 dist/
+
+.DS_Store

--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -885,7 +885,7 @@ actor ServerNetworkManager {
                                 .init(
                                     name: tool.name,
                                     description: tool.description,
-                                    inputSchema: try Value(tool.inputSchema),
+                                    inputSchema: try JSONSchemaToValueConverter.convert(tool.inputSchema),
                                     annotations: tool.annotations
                                 )
                             )

--- a/App/Models/JSONSchemaToValueConverter.swift
+++ b/App/Models/JSONSchemaToValueConverter.swift
@@ -1,0 +1,51 @@
+import Foundation
+import JSONSchema
+import MCP
+
+enum JSONSchemaToValueConverter {
+    static func convert(_ schema: JSONSchema) throws -> Value {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = []
+
+        let data = try encoder.encode(schema)
+        let jsonObject = try JSONSerialization.jsonObject(with: data)
+
+        return try convertJSONToValue(jsonObject)
+    }
+
+    private static func convertJSONToValue(_ object: Any) throws -> Value {
+        switch object {
+        case let dict as [String: Any]:
+            let convertedDict = try dict.mapValues { try convertJSONToValue($0) }
+            return .object(convertedDict)
+
+        case let array as [Any]:
+            let convertedArray = try array.map { try convertJSONToValue($0) }
+            return .array(convertedArray)
+
+        case let string as String:
+            return .string(string)
+
+        case let number as NSNumber:
+            if number === kCFBooleanTrue {
+                return .bool(true)
+            } else if number === kCFBooleanFalse {
+                return .bool(false)
+            } else if number.doubleValue == Double(number.intValue) {
+                return .int(number.intValue)
+            } else {
+                return .double(number.doubleValue)
+            }
+
+        case is NSNull:
+            return .null
+
+        default:
+            throw NSError(
+                domain: "JSONSchemaToValueConverter",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Unexpected JSON type: \(type(of: object))"]
+            )
+        }
+    }
+}

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -262,7 +262,7 @@ final class CalendarService: Service {
                                         ),
                                         "minutes": .integer(
                                             description:
-                                                "Minutes offset from event start (negative for before, positive for after)"
+                                                "Minutes offset from event start (negative for after, positive for before)"
                                         ),
                                         "sound": .string(
                                             description: "Sound name to play when alarm triggers",


### PR DESCRIPTION
Add custom JSONSchemaToValueConverter that properly serializes JSONSchema objects to JSON before converting to MCP Value type. This preserves complex schema constructs like anyOf, oneOf, and allOf that were previously lost.

The fix ensures Claude receives complete schema information for tools with union types. For example, the Calendar.events_create tool's 'alarms' parameter now properly exposes all three alarm type options (relative, absolute, proximity) with their specific required fields, allowing Claude to generate correct configurations.

Changes:
- Add JSONSchemaToValueConverter extension to serialize schemas with fidelity
- Update ServerController to use converter instead of direct Value initialization
- Fix Calendar.swift description accuracy for minutes field documentation

Verified: events_create schema now shows full anyOf union types.